### PR TITLE
Filter out ground points from virtual lidar

### DIFF
--- a/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
+++ b/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
@@ -23,7 +23,15 @@ local function frontObstacleDistance(veh, veh_props, maxDistance)
   local forwardOffset = 1.5
   local origin = vec3(pos.x + dir.x * forwardOffset, pos.y + dir.y * forwardOffset, pos.z + 0.5)
 
-  latest_point_cloud = virtual_lidar.scan(origin, dir, up, maxDistance, math.rad(30), math.rad(20), 15, 5)
+  local scan = virtual_lidar.scan(origin, dir, up, maxDistance, math.rad(30), math.rad(20), 15, 5)
+  local groundThreshold = -0.3
+  latest_point_cloud = {}
+  for _, p in ipairs(scan) do
+    local rel = p - origin
+    if rel:dot(up) >= groundThreshold then
+      latest_point_cloud[#latest_point_cloud + 1] = p
+    end
+  end
 
   local right = dir:cross(up)
   local half_width = veh_props.bb:getHalfExtents().x + 0.25


### PR DESCRIPTION
## Summary
- remove ground hits from virtual lidar data to avoid spurious obstacle detections
- base obstacle search on the filtered point cloud

## Testing
- `luac -p scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua scripts/driver_assistance_angelo234/virtualLidar.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c4e3195edc832999ce6a3e0a5c5501