### PR TITLE
Use vehicles on same road for auto headlight dimming

### DIFF
--- a/scripts/driver_assistance_angelo234/autoHeadlightSystem.lua
+++ b/scripts/driver_assistance_angelo234/autoHeadlightSystem.lua
@@ -28,7 +28,11 @@ end
 --If system just switched on, then check if highbeams are already on
 --if they are on, then make note of it
 local function systemSwitchedOn()
-  local light_state = electrics_values_angelo234["lights_state"]
+  local light_state = 0
+
+  if electrics_values_angelo234 ~= nil then
+    light_state = electrics_values_angelo234["lights_state"]
+  end
 
   if light_state == 2 then
     headlights_turned_off = false
@@ -69,16 +73,16 @@ local function autoHeadlightFunction(veh, vehs_in_front_table, light_state)
 end
 
 local function update(dt, veh, vehs_in_front_table)
-  local light_state = nil
+  local light_state = 0
 
   --This is to prevent headlight from turning back on due to delay
   --with sending data between Vehicle and GameEngine Lua
   if not headlights_turned_off then
-    light_state = electrics_values_angelo234["lights_state"]
+    if electrics_values_angelo234 ~= nil then
+      light_state = electrics_values_angelo234["lights_state"]
+    end
   else
-    light_state = 0
-
-    if electrics_values_angelo234["lights_state"] == 0 then
+    if electrics_values_angelo234 ~= nil and electrics_values_angelo234["lights_state"] == 0 then
       headlights_turned_off = false
     end
   end

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -17,7 +17,7 @@ local fcm_system = require('scripts/driver_assistance_angelo234/forwardCollision
 local rcm_system = require('scripts/driver_assistance_angelo234/reverseCollisionMitigationSystem')
 local acc_system = require('scripts/driver_assistance_angelo234/accSystem')
 local hsa_system = require('scripts/driver_assistance_angelo234/hillStartAssistSystem')
---local auto_headlight_system = require('scripts/driver_assistance_angelo234/autoHeadlightSystem')
+local auto_headlight_system = require('scripts/driver_assistance_angelo234/autoHeadlightSystem')
 
 local first_update = true
 
@@ -76,11 +76,11 @@ local function onVehicleSwitched(oid, nid, player)
 end
 
 local function onHeadlightsOff()
-  --auto_headlight_system.onHeadlightsOff()
+  auto_headlight_system.onHeadlightsOff()
 end
 
 local function onHeadlightsOn()
-  --auto_headlight_system.onHeadlightsOn()
+  auto_headlight_system.onHeadlightsOn()
 end
 
 --Functions called with key binding
@@ -117,8 +117,6 @@ local function toggleRCMSystem()
 end
 
 local function toggleAutoHeadlightSystem()
-  --[[
-
   if not extra_utils.getPart("auto_headlight_angelo234") then return end
 
   auto_headlight_system_on = not auto_headlight_system_on
@@ -132,8 +130,6 @@ local function toggleAutoHeadlightSystem()
   end
 
   ui_message("Auto Headlight Dimming switched " .. msg)
-
-  ]]--
 end
 
 local function setACCSystemOn(on)
@@ -305,10 +301,7 @@ local function onUpdate(dt)
     --p:add("hsa update")
   end
 
-  --AUTO HEADLIGHT SYSTEM DISABLED TEMPORARILY WHILE FINDING A FIX
-
-  --[[
-  --Update at 4 Hz
+  --Update Auto Headlight System at 4 Hz
   if auto_headlight_system_update_timer >= 0.25 then
     if extra_utils.getPart("auto_headlight_angelo234") and auto_headlight_system_on then
       if front_sensor_data ~= nil then
@@ -326,7 +319,6 @@ local function onUpdate(dt)
 
     --p:add("auto headlight update")
   end
-  ]]--
 
   --Update timers for updating systems
   other_systems_timer = other_systems_timer + dt

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -256,6 +256,7 @@ local function onUpdate(dt)
   if extra_utils.getPart("acc_angelo234")
   or extra_utils.getPart("forward_collision_mitigation_angelo234")
   or extra_utils.getPart("reverse_collision_mitigation_angelo234")
+  or extra_utils.getPart("auto_headlight_angelo234")
   then
     --Update at 120 Hz
     if other_systems_timer >= 1.0 / 120.0 then
@@ -309,7 +310,8 @@ local function onUpdate(dt)
           auto_headlight_system.systemSwitchedOn()
         end
 
-        auto_headlight_system.update(auto_headlight_system_update_timer, my_veh, front_sensor_data[2])
+        --Use only vehicles detected on the same road in front of the player
+        auto_headlight_system.update(auto_headlight_system_update_timer, my_veh, front_sensor_data[3])
       end
 
       auto_headlight_system_update_timer = 0


### PR DESCRIPTION
## Summary
- Use sensor data of vehicles on the same road to control automatic headlight dimming
- Poll front sensors when only the auto headlight system is installed so it can detect vehicles ahead

## Testing
- `luac -p scripts/driver_assistance_angelo234/extension.lua`
- `luac -p scripts/driver_assistance_angelo234/autoHeadlightSystem.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c6e0e968d48329bdf96eab7bb4e309