### PR TITLE
chore: upload test report artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,9 @@ jobs:
           total_fail=$((BUSTED_FAILURES + LUA_ERRORS + JS_ERRORS))
           total_error=$((BUSTED_ERRORS))
 
-          summary_file=$(mktemp)
+          summary_file=test-results.md
+          badge_file=tests-badge.svg
+          rm -f "$summary_file" "$badge_file"
           {
             echo "## Test Summary"
             echo
@@ -171,12 +173,22 @@ jobs:
             badge_url="https://img.shields.io/badge/tests-${badge_text}-${badge_color}"
             echo "![Tests](${badge_url})"
           } | tee "$summary_file"
+          curl -L "$badge_url" -o "$badge_file"
           cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
 
           printf 'summary<<EOF\n%s\nEOF\n' "$(cat "$summary_file")" >> "$GITHUB_OUTPUT"
           printf 'total_success=%s\n' "$total_success" >> "$GITHUB_OUTPUT"
           printf 'total_fail=%s\n' "$total_fail" >> "$GITHUB_OUTPUT"
           printf 'total_error=%s\n' "$total_error" >> "$GITHUB_OUTPUT"
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: |
+            test-results.md
+            tests-badge.svg
 
       - name: Annotate check name
         if: always()


### PR DESCRIPTION
## Summary
- save test summary and badge to files during CI
- upload badge and summary as workflow artifacts

## Testing
- `find . -name '*.lua' ...` (syntax check)
- `find . -name '*.js' ...` (no JS files)
- `busted`


------
https://chatgpt.com/codex/tasks/task_e_68c7056638448329b84c8c275a4d99dc