### PR TITLE
Guard virtual lidar update when vehicle methods missing

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -272,6 +272,7 @@ end
 
 local function updateVirtualLidar(dt, veh)
   if not aeb_params then return end
+  if not veh or not veh.getPosition or not veh.getDirectionVector or not veh.getDirectionVectorUp then return end
   if virtual_lidar_update_timer >= 1.0 / 20.0 then
     local pos = veh:getPosition()
     local dir = veh:getDirectionVector()


### PR DESCRIPTION
## Summary
- skip virtual lidar update if vehicle object lacks position/direction methods

## Testing
- `busted`


------
https://chatgpt.com/codex/tasks/task_e_68c7313254d88329a72576f60bba880f