### PR TITLE
Integrate front/rear sensors with virtual lidar

### DIFF
--- a/.tests/extension_spec.lua
+++ b/.tests/extension_spec.lua
@@ -104,4 +104,66 @@ describe('extension', function()
     assert.is_true(poll_called > 0)
     assert.equal(sample_front_data[2], passed_vehs)
   end)
+
+  it('does not run obstacle AEB without the part installed', function()
+    local aeb_called = 0
+
+    package.loaded['scripts/driver_assistance_angelo234/extraUtils'] = {
+      getPart = function(part)
+        if part == 'obstacle_collision_mitigation_angelo234' then return true end
+        if part == 'obstacle_aeb_angelo234' then return false end
+        if part == 'auto_headlight_angelo234' then return false end
+        return nil
+      end,
+      getVehicleProperties = function() return {id = 1} end
+    }
+    package.loaded['scripts/driver_assistance_angelo234/sensorSystem'] = {
+      pollFrontSensors = function() return {0, {}, {}} end,
+      pollRearSensors = function() return {nil} end,
+    }
+    package.loaded['scripts/driver_assistance_angelo234/forwardCollisionMitigationSystem'] = {}
+    package.loaded['scripts/driver_assistance_angelo234/reverseCollisionMitigationSystem'] = {}
+    package.loaded['scripts/driver_assistance_angelo234/accSystem'] = {}
+    package.loaded['scripts/driver_assistance_angelo234/hillStartAssistSystem'] = {}
+    package.loaded['scripts/driver_assistance_angelo234/autoHeadlightSystem'] = {
+      onHeadlightsOff = function() end,
+      onHeadlightsOn = function() end,
+      systemSwitchedOn = function() end,
+      update = function() end,
+    }
+    package.loaded['scripts/driver_assistance_angelo234/obstacleBrakingSystem'] = {
+      update = function() aeb_called = aeb_called + 1 end
+    }
+
+    _G.be = {
+      getPlayerVehicle = function()
+        return { getJBeamFilename = function() return 'common' end, queueLuaCommand = function() end }
+      end,
+      getObjectCount = function() return 0 end,
+      getObject = function() return nil end,
+      getEnabled = function() return true end
+    }
+    _G.FS = { fileExists = function() return false end }
+    _G.ui_message = function() end
+
+    _G.newExponentialSmoothing = function() return { get = function(self, v) return v end } end
+    _G.jsonDecode = function(x) return x end
+    _G.jsonEncode = function(x) return x end
+
+    _G.veh_accs_angelo234 = { [1] = {0,0,0} }
+    _G.electrics_values_angelo234 = { [1] = 0, lights_state = 0 }
+    _G.angular_speed_angelo234 = 0
+    _G.input_throttle_angelo234 = 0
+    _G.input_brake_angelo234 = 0
+    _G.input_clutch_angelo234 = 0
+    _G.input_parkingbrake_angelo234 = 0
+    _G.gearbox_mode_angelo234 = 'dummy'
+
+    local extension = require('scripts/driver_assistance_angelo234/extension')
+    extension.onExtensionLoaded()
+    extension.onUpdate(0.3)
+    extension.onUpdate(0.3)
+
+    assert.equal(0, aeb_called)
+  end)
 end)

--- a/.tests/sensor_system_spec.lua
+++ b/.tests/sensor_system_spec.lua
@@ -50,6 +50,7 @@ end
 
 local logger = require('scripts/driver_assistance_angelo234/logger')
 logger.setEnabled(true)
+logger.setSensorEnabled('front_sensor', true)
 
 local sensor_system = require('scripts/driver_assistance_angelo234/sensorSystem')
 

--- a/.tests/virtual_lidar_spec.lua
+++ b/.tests/virtual_lidar_spec.lua
@@ -1,0 +1,44 @@
+local vec_mt = {}
+vec_mt.__index = vec_mt
+function vec_mt.__add(a, b) return vec3(a.x + b.x, a.y + b.y, a.z + b.z) end
+function vec_mt.__sub(a, b) return vec3(a.x - b.x, a.y - b.y, a.z - b.z) end
+function vec_mt.__mul(a, b)
+  if type(a) == 'number' then return vec3(a * b.x, a * b.y, a * b.z)
+  elseif type(b) == 'number' then return vec3(a.x * b, a.y * b, a.z * b) end
+end
+function vec_mt:dot(b) return self.x * b.x + self.y * b.y + self.z * b.z end
+function vec_mt:cross(b)
+  return vec3(self.y * b.z - self.z * b.y, self.z * b.x - self.x * b.z, self.x * b.y - self.y * b.x)
+end
+function vec_mt:length() return math.sqrt(self:dot(self)) end
+function vec_mt:normalized()
+  local l = self:length()
+  if l == 0 then return vec3(0, 0, 0) end
+  return self * (1 / l)
+end
+
+function vec3(x, y, z)
+  return setmetatable({x = x or 0, y = y or 0, z = z or 0}, vec_mt)
+end
+
+describe('virtual lidar scan', function()
+  before_each(function()
+    package.loaded['scripts/driver_assistance_angelo234/virtualLidar'] = nil
+  end)
+
+  it('filters hits from the host vehicle', function()
+    _G.castRayStatic = function() return nil end
+    _G.castRay = function() return {dist = 5, pt = vec3(0, 5, 0), obj = {getID = function() return 1 end}} end
+    local lidar = require('scripts/driver_assistance_angelo234/virtualLidar')
+    local pts = lidar.scan(vec3(), vec3(0, 1, 0), vec3(0, 0, 1), 10, 0, 0, 1, 1, 0, 1)
+    assert.equal(0, #pts)
+  end)
+
+  it('includes hits from other vehicles', function()
+    _G.castRayStatic = function() return nil end
+    _G.castRay = function() return {dist = 5, pt = vec3(0, 5, 0), obj = {getID = function() return 2 end}} end
+    local lidar = require('scripts/driver_assistance_angelo234/virtualLidar')
+    local pts = lidar.scan(vec3(), vec3(0, 1, 0), vec3(0, 0, 1), 10, 0, 0, 1, 1, 0, 1)
+    assert.equal(1, #pts)
+  end)
+end)

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -347,16 +347,16 @@ local function updateVirtualLidar(dt, veh)
         center + x + y + z,
         center + x - y + z,
         center - x + y + z,
-        center - x - y + z
+        center - x - y + z,
+        center + x + y - z,
+        center + x - y - z,
+        center - x + y - z,
+        center - x - y - z
       }
       for _, c in ipairs(corners) do
         local rel = c - origin
-        local dist = rel:length()
-        if dist < max_dist then
-          local hit = castRay(origin, origin + rel, true, true)
-          if hit and hit.obj and hit.obj.getID and hit.obj:getID() == props.id then
-            hits[#hits + 1] = hit.pt
-          end
+        if rel:length() < max_dist then
+          hits[#hits + 1] = c
         end
       end
       local id = vehObj.getJBeamFilename and vehObj:getJBeamFilename() or tostring(vehObj:getID())
@@ -482,7 +482,9 @@ local function onUpdate(dt)
           end
 
           --Update Obstacle Collision Mitigation System
-          if extra_utils.getPart("obstacle_collision_mitigation_angelo234") and obstacle_aeb_system_on then
+          if extra_utils.getPart("obstacle_collision_mitigation_angelo234")
+            and extra_utils.getPart("obstacle_aeb_angelo234")
+            and obstacle_aeb_system_on then
             obstacle_aeb_system.update(
               other_systems_timer * 2,
               my_veh,

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -271,6 +271,10 @@ end
 --local p = LuaProfiler("my profiler")
 
 local function updateVirtualLidar(dt, veh, front_sensors, rear_sensors)
+  if not extra_utils.getPart("lidar_angelo234") then
+    virtual_lidar_point_cloud = {}
+    return
+  end
   if not aeb_params then return end
   if not veh or not veh.getPosition or not veh.getDirectionVector or not veh.getDirectionVectorUp then return end
   if virtual_lidar_update_timer >= 1.0 / 20.0 then
@@ -377,8 +381,10 @@ local function onUpdate(dt)
   local veh_props = extra_utils.getVehicleProperties(my_veh)
   local need_front_sensors = extra_utils.getPart("acc_angelo234")
     or extra_utils.getPart("forward_collision_mitigation_angelo234")
+    or extra_utils.getPart("obstacle_collision_mitigation_angelo234")
     or (extra_utils.getPart("auto_headlight_angelo234") and auto_headlight_system_on)
   local need_rear_sensors = extra_utils.getPart("reverse_collision_mitigation_angelo234")
+    or extra_utils.getPart("obstacle_collision_mitigation_angelo234")
 
   if need_front_sensors or need_rear_sensors then
     --Update at 120 Hz

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -331,10 +331,11 @@ local function updateVirtualLidar(dt, veh)
     )
 
     local detections = {}
-    local processed = {}
+    local processed = {[veh:getID()] = true}
 
     local function addVehicle(vehObj, props)
-      if not vehObj or not props or processed[props.id] then return end
+      if not vehObj or not props then return end
+      if props.id == veh:getID() or processed[props.id] then return end
       processed[props.id] = true
       local bb = props.bb
       if not bb then return end

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -383,13 +383,6 @@ local function updateVirtualLidar(dt, veh)
       end
     end
 
-    for i = 0, be:getObjectCount() - 1 do
-      local other = be:getObject(i)
-      if other:getID() ~= veh:getID() and other:getJBeamFilename() ~= "unicycle" then
-        addVehicle(other)
-      end
-    end
-
     local hostBB = veh_props and veh_props.bb
     local hostCenter, hostX, hostY, hostZ, hostExt
     if hostBB then
@@ -409,7 +402,13 @@ local function updateVirtualLidar(dt, veh)
         local hx = relHost:dot(hostX)
         local hy = relHost:dot(hostY)
         local hz = relHost:dot(hostZ)
-        if math.abs(hx) <= hostExt.x + 1 and math.abs(hy) <= hostExt.y + 1 and math.abs(hz) <= hostExt.z + 1 then
+        --
+        -- Some vehicle mods spawn helper objects whose bounding boxes roughly match
+        -- the host vehicle but are offset by a couple of metres.  Those objects end
+        -- up in the scan as ghost silhouettes.  Filter out any hits that fall within
+        -- a generously expanded version of our own bounding box to remove these
+        -- stray points while still allowing nearby traffic to appear.
+        if math.abs(hx) <= hostExt.x + 3 and math.abs(hy) <= hostExt.y + 3 and math.abs(hz) <= hostExt.z + 1 then
           skip = true
         end
       end

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -191,6 +191,24 @@ local function toggleDebugLogging()
   ui_message("Driver assistance logs " .. msg)
 end
 
+local function toggleFrontSensorLogging()
+  local enabled = logger.toggleSensor('front_sensor')
+  local msg = enabled and "enabled" or "disabled"
+  ui_message("Front sensor logs " .. msg)
+end
+
+local function toggleRearSensorLogging()
+  local enabled = logger.toggleSensor('rear_sensor')
+  local msg = enabled and "enabled" or "disabled"
+  ui_message("Rear sensor logs " .. msg)
+end
+
+local function toggleLidarLogging()
+  local enabled = logger.toggleSensor('lidar')
+  local msg = enabled and "enabled" or "disabled"
+  ui_message("Lidar logs " .. msg)
+end
+
 --Used for what camera to switch the player to when the player gets out of reverse gear using reverse camera
 local function onCameraModeChanged(new_camera_mode)
   if new_camera_mode ~= M.curr_camera_mode then
@@ -313,6 +331,8 @@ local function updateVirtualLidar(dt, veh)
           local hit = castRay(origin, origin + rayDir * dist, true, true)
           if hit and hit.obj and hit.obj.getID and hit.obj:getID() == props.id then
             hits[#hits + 1] = hit.pt
+            local id = other.getJBeamFilename and other:getJBeamFilename() or tostring(other:getID())
+            logger.log('I', 'lidar', string.format('Detected vehicle %s at %.1f', id, dist))
           end
         end
       end
@@ -512,6 +532,9 @@ M.setACCSpeed = setACCSpeed
 M.changeACCSpeed = changeACCSpeed
 M.changeACCFollowingDistance = changeACCFollowingDistance
 M.toggleDebugLogging = toggleDebugLogging
+M.toggleFrontSensorLogging = toggleFrontSensorLogging
+M.toggleRearSensorLogging = toggleRearSensorLogging
+M.toggleLidarLogging = toggleLidarLogging
 M.onCameraModeChanged = onCameraModeChanged
 M.onUpdate = onUpdate
 M.onInit = onInit

--- a/scripts/driver_assistance_angelo234/logger.lua
+++ b/scripts/driver_assistance_angelo234/logger.lua
@@ -1,4 +1,11 @@
-local M = { enabled = false }
+local M = {
+  enabled = false,
+  sensors = {
+    front_sensor = false,
+    rear_sensor = false,
+    lidar = false
+  }
+}
 
 function M.setEnabled(value)
   M.enabled = value and true or false
@@ -9,13 +16,33 @@ function M.toggle()
   return M.enabled
 end
 
+function M.setSensorEnabled(sensor, value)
+  if M.sensors[sensor] ~= nil then
+    M.sensors[sensor] = value and true or false
+  end
+end
+
+function M.toggleSensor(sensor)
+  if M.sensors[sensor] ~= nil then
+    M.sensors[sensor] = not M.sensors[sensor]
+    return M.sensors[sensor]
+  end
+end
+
 function M.isEnabled()
   return M.enabled
 end
 
+function M.isSensorEnabled(sensor)
+  return M.sensors[sensor]
+end
+
 function M.log(level, tag, msg)
   if M.enabled and log then
-    log(level, tag, msg)
+    local sensor_flag = M.sensors[tag]
+    if sensor_flag == nil or sensor_flag then
+      log(level, tag, msg)
+    end
   end
 end
 

--- a/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
+++ b/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
@@ -25,7 +25,7 @@ local function enableABS(veh)
 end
 
 -- speed is in m/s and is used to relax slope filtering at lower speeds
-local function frontObstacleDistance(veh, veh_props, aeb_params, speed)
+local function frontObstacleDistance(veh, veh_props, aeb_params, speed, front_sensors, rear_sensors)
   local maxDistance = aeb_params.sensor_max_distance
   local pos = veh:getPosition()
   local dir = veh:getDirectionVector()
@@ -38,6 +38,36 @@ local function frontObstacleDistance(veh, veh_props, aeb_params, speed)
 
   local scan =
     virtual_lidar.scan(origin, dir, up, maxDistance, math.rad(30), math.rad(20), 30, 10, 0, veh:getID())
+
+  -- augment scan with sensor data
+  if front_sensors then
+    local front_static = front_sensors[1]
+    if front_static and front_static < 9999 then
+      scan[#scan + 1] = origin + dir * front_static
+    end
+    local vehs = front_sensors[2]
+    if vehs then
+      for _, data in ipairs(vehs) do
+        if data.other_veh_props and data.other_veh_props.center_pos then
+          scan[#scan + 1] = data.other_veh_props.center_pos
+        end
+      end
+    end
+  end
+
+  if rear_sensors then
+    local rear_vehicle = rear_sensors[1]
+    local rear_dist = rear_sensors[2]
+    if rear_dist and rear_dist < 9999 then
+      scan[#scan + 1] = origin - dir * rear_dist
+    end
+    if rear_vehicle then
+      local props = extra_utils.getVehicleProperties(rear_vehicle)
+      if props and props.center_pos then
+        scan[#scan + 1] = props.center_pos
+      end
+    end
+  end
 
   -- ignore points below groundThreshold or above the vehicle roof to avoid
   -- triggering on walkways or bridges that are safe to pass under
@@ -203,14 +233,14 @@ local function performEmergencyBraking(dt, veh, aeb_params, time_before_braking,
   end
 end
 
-local function update(dt, veh, system_params, aeb_params, beeper_params)
+local function update(dt, veh, system_params, aeb_params, beeper_params, front_sensors, rear_sensors)
   local veh_props = extra_utils.getVehicleProperties(veh)
   if holdBrakes(veh, veh_props, aeb_params) then return end
 
   local forward_speed = veh_props.velocity:dot(veh_props.dir)
   if forward_speed <= aeb_params.min_speed then return end
 
-  local distance, side_clearance = frontObstacleDistance(veh, veh_props, aeb_params, forward_speed)
+  local distance, side_clearance = frontObstacleDistance(veh, veh_props, aeb_params, forward_speed, front_sensors, rear_sensors)
 
   local side_threshold = aeb_params.side_clearance_threshold or 0.3
   if side_clearance and side_clearance < side_threshold then

--- a/scripts/driver_assistance_angelo234/sensorSystem.lua
+++ b/scripts/driver_assistance_angelo234/sensorSystem.lua
@@ -351,10 +351,10 @@ local function pollFrontSensors(dt, veh_props, system_params, aeb_params)
       local veh = data.other_veh
       local id = veh.getJBeamFilename and veh:getJBeamFilename() or tostring(veh:getID())
       local veh_type = isPlayerVehicle(veh) and 'player vehicle' or 'traffic vehicle'
-      logger.log('I', 'sensor_system', string.format('Front sensor detected %s %s at %.1f', veh_type, id, data.shortest_dist))
+      logger.log('I', 'front_sensor', string.format('Front sensor detected %s %s at %.1f', veh_type, id, data.shortest_dist))
     end
   elseif front_static_min_dist < 9999 then
-    logger.log('I', 'sensor_system', string.format('Front sensor detected obstacle at %.1f', front_static_min_dist))
+    logger.log('I', 'front_sensor', string.format('Front sensor detected obstacle at %.1f', front_static_min_dist))
   end
 
   --p:finish(true)
@@ -416,6 +416,17 @@ local function pollRearSensors(dt, veh_props, system_params, rev_aeb_params)
   local other_vehs_data = getNearbyVehicles(dt, veh_props, rev_aeb_params.sensor_max_distance, false)
 
   local data = processRearSensorData(rear_static_min_dist, other_vehs_data, rev_aeb_params)
+
+  if other_vehs_data and #other_vehs_data > 0 then
+    for _, d in pairs(other_vehs_data) do
+      local veh = d.other_veh
+      local id = veh.getJBeamFilename and veh:getJBeamFilename() or tostring(veh:getID())
+      local veh_type = isPlayerVehicle(veh) and 'player vehicle' or 'traffic vehicle'
+      logger.log('I', 'rear_sensor', string.format('Rear sensor detected %s %s at %.1f', veh_type, id, d.shortest_dist))
+    end
+  elseif rear_static_min_dist < 9999 then
+    logger.log('I', 'rear_sensor', string.format('Rear sensor detected obstacle at %.1f', rear_static_min_dist))
+  end
 
   return data
 end

--- a/scripts/driver_assistance_angelo234/virtualLidar.lua
+++ b/scripts/driver_assistance_angelo234/virtualLidar.lua
@@ -38,9 +38,15 @@ local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, i
         pt = origin + rayDir * staticDist
       end
       if dynHit and dynHit.dist and dynHit.dist < maxDist then
-        local hitId = dynHit.objectId or dynHit.objectID or dynHit.cid
-        if not hitId and dynHit.obj and dynHit.obj.getID then
-          hitId = dynHit.obj:getID()
+        local obj = dynHit.obj
+        local hitId = dynHit.objectId or dynHit.objectID
+        if obj and obj.getID then
+          local objId = obj:getID()
+          if ignoreId and objId == ignoreId then
+            hitId = nil
+          elseif not hitId then
+            hitId = objId
+          end
         end
         if hitId and (not ignoreId or hitId ~= ignoreId) then
           if not dist or dynHit.dist < dist then

--- a/scripts/driver_assistance_angelo234/virtualLidar.lua
+++ b/scripts/driver_assistance_angelo234/virtualLidar.lua
@@ -42,7 +42,7 @@ local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, i
         if not hitId and dynHit.obj and dynHit.obj.getID then
           hitId = dynHit.obj:getID()
         end
-        if not ignoreId or hitId ~= ignoreId then
+        if hitId and (not ignoreId or hitId ~= ignoreId) then
           if not dist or dynHit.dist < dist then
             dist = dynHit.dist
             pt = dynHit.pt

--- a/vehicles/common/lidar_angelo234.jbeam
+++ b/vehicles/common/lidar_angelo234.jbeam
@@ -1,0 +1,10 @@
+{
+    "lidar_angelo234": {
+        "information":{
+            "authors":"angelo234",
+            "name":"Lidar",
+            "value":250,
+        },
+        "slotType" : "lidar_angelo234",
+    },
+}

--- a/vehicles/common/obstacle_collision_mitigation_angelo234.jbeam
+++ b/vehicles/common/obstacle_collision_mitigation_angelo234.jbeam
@@ -9,6 +9,7 @@
         "slots": [
             ["type", "default", "description"],
             ["obstacle_aeb_angelo234", "obstacle_aeb_angelo234", "Obstacle AEB"],
+            ["lidar_angelo234", "", "Lidar"],
         ],
     },
 }


### PR DESCRIPTION
## Summary
- feed front and rear sensor data into virtual lidar and expose combined point cloud
- supply sensor data to obstacle braking system
- augment obstacle collision logic to consider sensor-provided vehicles and obstacles

## Testing
- `busted spec`


------
https://chatgpt.com/codex/tasks/task_e_68c733a582e883298365a62ba15a78ca