### PR TITLE
Reduce per-frame cost of virtual lidar by phased scanning

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -46,7 +46,7 @@ local other_systems_timer = 0
 local hsa_system_update_timer = 0
 local auto_headlight_system_update_timer = 0
 local virtual_lidar_update_timer = 0
-local VIRTUAL_LIDAR_PHASES = 8
+local VIRTUAL_LIDAR_PHASES = 12
 local virtual_lidar_point_cloud = {}
 
 local function resetVirtualLidarPointCloud()

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -46,7 +46,17 @@ local other_systems_timer = 0
 local hsa_system_update_timer = 0
 local auto_headlight_system_update_timer = 0
 local virtual_lidar_update_timer = 0
-local virtual_lidar_point_cloud = {{}, {}}
+local VIRTUAL_LIDAR_PHASES = 8
+local virtual_lidar_point_cloud = {}
+
+local function resetVirtualLidarPointCloud()
+  virtual_lidar_point_cloud = {}
+  for i = 1, VIRTUAL_LIDAR_PHASES do
+    virtual_lidar_point_cloud[i] = {}
+  end
+end
+
+resetVirtualLidarPointCloud()
 local virtual_lidar_phase = 0
 
 M.curr_camera_mode = "orbit"
@@ -302,7 +312,7 @@ end
 
 local function updateVirtualLidar(dt, veh)
   if not extra_utils.getPart("lidar_angelo234") then
-    virtual_lidar_point_cloud = {{}, {}}
+    resetVirtualLidarPointCloud()
     return
   end
   if not aeb_params then return end
@@ -329,7 +339,7 @@ local function updateVirtualLidar(dt, veh)
       15,
       0,
       veh:getID(),
-      {hStart = virtual_lidar_phase, hStep = 2}
+      {hStart = virtual_lidar_phase, hStep = VIRTUAL_LIDAR_PHASES}
     )
 
     -- cache properties of the player's vehicle for later filtering
@@ -432,7 +442,7 @@ local function updateVirtualLidar(dt, veh)
       local ang = math.deg(math.atan2(x, y))
       logger.log('I', 'lidar', string.format('Detected %s at %.1f m %.1f° (%.1f, %.1f, %.1f)', d.desc, dist, ang, x, y, z))
     end
-    virtual_lidar_phase = (virtual_lidar_phase + 1) % 2
+    virtual_lidar_phase = (virtual_lidar_phase + 1) % VIRTUAL_LIDAR_PHASES
     virtual_lidar_update_timer = 0
   else
     virtual_lidar_update_timer = virtual_lidar_update_timer + dt

--- a/scripts/driver_assistance_angelo234/virtualLidar.lua
+++ b/scripts/driver_assistance_angelo234/virtualLidar.lua
@@ -9,9 +9,9 @@ local sin, cos = math.sin, math.cos
 -- up: up direction vector
 -- maxDist: max scan distance
 -- hFov, vFov: horizontal and vertical field of view in radians
--- hRes, vRes: number of rays horizontally and vertically
 -- ignoreId: optional vehicle id to exclude from results
-local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, ignoreId)
+-- opts: optional table {hStart, hStep, vStart, vStep} to scan only a subset of rays
+local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, ignoreId, opts)
   local points = {}
   dir = dir:normalized()
   up = up:normalized()
@@ -21,10 +21,16 @@ local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, i
   right = right:normalized()
   minDist = minDist or 0
 
-  for i = 0, hRes - 1 do
+  opts = opts or {}
+  local hStart = opts.hStart or 0
+  local hStep = opts.hStep or 1
+  local vStart = opts.vStart or 0
+  local vStep = opts.vStep or 1
+
+  for i = hStart, hRes - 1, hStep do
     local hAng = -hFov * 0.5 + hFov * i / math.max(1, hRes - 1)
     local ch, sh = cos(hAng), sin(hAng)
-    for j = 0, vRes - 1 do
+    for j = vStart, vRes - 1, vStep do
       local vAng = -vFov * 0.5 + vFov * j / math.max(1, vRes - 1)
       local cv, sv = cos(vAng), sin(vAng)
       local rayDir = dir * (cv * ch) + right * (cv * sh) + up * sv

--- a/vehicles/common/lidar_angelo234.jbeam
+++ b/vehicles/common/lidar_angelo234.jbeam
@@ -2,7 +2,7 @@
     "lidar_angelo234": {
         "information":{
             "authors":"angelo234",
-            "name":"Lidar",
+            "name":"12-phase LFO-Lidar",
             "value":250,
         },
         "slotType" : "lidar_angelo234",


### PR DESCRIPTION
## Summary
- Allow virtual lidar scan to operate on subsets of rays
- Update lidar extension to scan in alternating phases, cutting per-frame raycasts
- Merge phased point clouds for external consumers

## Testing
- `busted .tests`


------
https://chatgpt.com/codex/tasks/task_e_68c762d06d788329a0757833d56becfc