### PR TITLE
Optimize virtual lidar for high-speed forward scanning

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -328,19 +328,58 @@ local function updateVirtualLidar(dt, veh)
     -- In BeamNG's left-handed system, forward × up yields the vehicle's right
     local right = dir:cross(up):normalized()
     local max_dist = aeb_params.sensor_max_distance
-    local hits = virtual_lidar.scan(
-      origin,
-      dir,
-      up,
-      max_dist,
-      math.rad(360),
-      math.rad(30),
-      60,
-      15,
-      0,
-      veh:getID(),
-      {hStart = virtual_lidar_phase, hStep = VIRTUAL_LIDAR_PHASES}
-    )
+    local vel = veh:getVelocity()
+    local forward_speed = vel:dot(dir) * 3.6
+    local hits
+
+    if forward_speed > 35 then
+      local FRONT_PHASES = 8
+      local REAR_PHASES = VIRTUAL_LIDAR_PHASES - FRONT_PHASES
+      if virtual_lidar_phase < FRONT_PHASES then
+        hits = virtual_lidar.scan(
+          origin,
+          dir,
+          up,
+          max_dist,
+          math.rad(135),
+          math.rad(30),
+          40,
+          15,
+          0,
+          veh:getID(),
+          {hStart = virtual_lidar_phase, hStep = FRONT_PHASES}
+        )
+      else
+        local back_phase = virtual_lidar_phase - FRONT_PHASES
+        hits = virtual_lidar.scan(
+          origin,
+          -dir,
+          up,
+          max_dist,
+          math.rad(225),
+          math.rad(30),
+          20,
+          15,
+          0,
+          veh:getID(),
+          {hStart = back_phase, hStep = REAR_PHASES}
+        )
+      end
+    else
+      hits = virtual_lidar.scan(
+        origin,
+        dir,
+        up,
+        max_dist,
+        math.rad(360),
+        math.rad(30),
+        60,
+        15,
+        0,
+        veh:getID(),
+        {hStart = virtual_lidar_phase, hStep = VIRTUAL_LIDAR_PHASES}
+      )
+    end
 
     -- cache properties of the player's vehicle for later filtering
     local veh_props = extra_utils.getVehicleProperties(veh)

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -328,9 +328,10 @@ local function updateVirtualLidar(dt, veh)
     -- In BeamNG's left-handed system, forward × up yields the vehicle's right
     local right = dir:cross(up):normalized()
     local max_dist = aeb_params.sensor_max_distance
+    -- keep full lidar range ahead, but halve reach for rear and side sectors
     local front_dist = max_dist
     local rear_dist = max_dist * 0.5
-    local side_dist = max_dist * 0.25
+    local side_dist = rear_dist
     local ANG_FRONT = 67.5
     local ANG_SIDE = 112.5
     local vel = veh:getVelocity()


### PR DESCRIPTION
## Summary
- Prioritize 135° forward lidar coverage when traveling faster than 35 km/h
- Fall back to original 360° scan pattern at lower speeds or while reversing

## Testing
- `busted -v .tests`
- `busted -v spec`


------
https://chatgpt.com/codex/tasks/task_e_68c7727acdb483298a0a5440dee78f5b