### PR TITLE
Fix virtual Lidar app zoom and vehicle color

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -673,8 +673,10 @@ end
 
 local function getVehicleColor()
   local veh = be:getPlayerVehicle(0)
-  if veh and veh.getColor then
-    local c = veh:getColor()
+  if veh then
+    -- Some vehicle APIs expose color via a "color" field rather than a getter.
+    -- Fall back to veh:getColor() when available for older versions.
+    local c = veh.color or (veh.getColor and veh:getColor())
     if c then
       local r = c.x or c.r or 1
       local g = c.y or c.g or 1

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -685,6 +685,10 @@ local function getVehicleColor()
   return {255, 255, 255}
 end
 
+local function getVirtualLidarData()
+  return {points = getVirtualLidarPointCloud(), color = getVehicleColor()}
+end
+
 local function getLaneSensorData()
   return lane_assist_system.getSensorData()
 end
@@ -716,6 +720,7 @@ M.onUpdate = onUpdate
 M.onInit = onInit
 M.getVirtualLidarPointCloud = getVirtualLidarPointCloud
 M.getVehicleColor = getVehicleColor
+M.getVirtualLidarData = getVirtualLidarData
 M.getLaneSensorData = getLaneSensorData
 
 return M

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -671,6 +671,20 @@ local function getVirtualLidarPointCloud()
   return combined
 end
 
+local function getVehicleColor()
+  local veh = be:getPlayerVehicle(0)
+  if veh and veh.getColor then
+    local c = veh:getColor()
+    if c then
+      local r = c.x or c.r or 1
+      local g = c.y or c.g or 1
+      local b = c.z or c.b or 1
+      return {r * 255, g * 255, b * 255}
+    end
+  end
+  return {255, 255, 255}
+end
+
 local function getLaneSensorData()
   return lane_assist_system.getSensorData()
 end
@@ -701,6 +715,7 @@ M.onCameraModeChanged = onCameraModeChanged
 M.onUpdate = onUpdate
 M.onInit = onInit
 M.getVirtualLidarPointCloud = getVirtualLidarPointCloud
+M.getVehicleColor = getVehicleColor
 M.getLaneSensorData = getLaneSensorData
 
 return M

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -679,10 +679,10 @@ local function getVehicleColor()
       local r = c.x or c.r or 1
       local g = c.y or c.g or 1
       local b = c.z or c.b or 1
-      return {r * 255, g * 255, b * 255}
+      return {r = r * 255, g = g * 255, b = b * 255}
     end
   end
-  return {255, 255, 255}
+  return {r = 255, g = 255, b = 255}
 end
 
 local function getVirtualLidarData()

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -59,12 +59,16 @@ angular.module('beamng.apps')
       }
 
       function update() {
-        bngApi.engineLua("local e=extensions.driver_assistance_angelo234; return {points=e.getVirtualLidarPointCloud(), color=e.getVehicleColor()}", function (data) {
-          $scope.$evalAsync(function () {
-            if (data.color) { carColor = data.color; }
-            draw(data.points);
-          });
-        });
+        bngApi.engineLua(
+          'return {points=extensions.driver_assistance_angelo234.getVirtualLidarPointCloud(), ' +
+          'color=extensions.driver_assistance_angelo234.getVehicleColor()}',
+          function (data) {
+            $scope.$evalAsync(function () {
+              if (data.color) { carColor = data.color; }
+              draw(data.points);
+            });
+          }
+        );
       }
 
       var interval = setInterval(update, 100);

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -8,10 +8,16 @@ angular.module('beamng.apps')
     controller: ['$scope', '$element', function ($scope, $element) {
       var canvas = $element.find('canvas')[0];
       var ctx = canvas.getContext('2d');
+      // Fixed world range for drawing (in meters). Keeps zoom stable.
+      var FIXED_RANGE = 60;
+      var carColor = [255, 255, 255];
 
       function drawVehicle() {
         ctx.save();
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+        ctx.fillStyle = 'rgba(' +
+          Math.round(carColor[0]) + ',' +
+          Math.round(carColor[1]) + ',' +
+          Math.round(carColor[2]) + ',0.5)';
         var carWidth = 10;
         var carLength = 20;
         ctx.translate(canvas.width / 2, canvas.height / 2);
@@ -26,23 +32,18 @@ angular.module('beamng.apps')
           return;
         }
 
-        var maxAbsX = 0, maxAbsY = 0;
         var minD = Infinity, maxD = -Infinity;
 
         points.forEach(function (p) {
-          if (Math.abs(p.x) > maxAbsX) { maxAbsX = Math.abs(p.x); }
-          if (Math.abs(p.y) > maxAbsY) { maxAbsY = Math.abs(p.y); }
-
           var d = Math.sqrt(p.x * p.x + p.y * p.y + p.z * p.z);
           if (d < minD) { minD = d; }
           if (d > maxD) { maxD = d; }
           p._d = d;
         });
 
-        var range = Math.max(1, Math.max(maxAbsX, maxAbsY));
         var scale = Math.min(
-          canvas.width / (2 * range),
-          canvas.height / (2 * range)
+          canvas.width / (2 * FIXED_RANGE),
+          canvas.height / (2 * FIXED_RANGE)
         );
         var distRange = Math.max(1, maxD - minD);
 
@@ -58,9 +59,10 @@ angular.module('beamng.apps')
       }
 
       function update() {
-        bngApi.engineLua('extensions.driver_assistance_angelo234.getVirtualLidarPointCloud()', function (data) {
+        bngApi.engineLua("local e=extensions.driver_assistance_angelo234; return {points=e.getVirtualLidarPointCloud(), color=e.getVehicleColor()}", function (data) {
           $scope.$evalAsync(function () {
-            draw(data);
+            if (data.color) { carColor = data.color; }
+            draw(data.points);
           });
         });
       }

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -60,8 +60,7 @@ angular.module('beamng.apps')
 
       function update() {
         bngApi.engineLua(
-          'return {points=extensions.driver_assistance_angelo234.getVirtualLidarPointCloud(), ' +
-          'color=extensions.driver_assistance_angelo234.getVehicleColor()}',
+          'extensions.driver_assistance_angelo234.getVirtualLidarData()',
           function (data) {
             $scope.$evalAsync(function () {
               if (data.color) { carColor = data.color; }

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -63,7 +63,13 @@ angular.module('beamng.apps')
           'extensions.driver_assistance_angelo234.getVirtualLidarData()',
           function (data) {
             $scope.$evalAsync(function () {
-              if (data.color) { carColor = data.color; }
+              if (data.color) {
+                carColor = [
+                  typeof data.color.r === 'number' ? data.color.r : 255,
+                  typeof data.color.g === 'number' ? data.color.g : 255,
+                  typeof data.color.b === 'number' ? data.color.b : 255
+                ];
+              }
               draw(data.points);
             });
           }


### PR DESCRIPTION
## Summary
- Keep virtual Lidar view at a fixed zoom level
- Color the vehicle marker to match the player's car color
- Expose vehicle color retrieval in Lua extension

## Testing
- `busted .tests`


------
https://chatgpt.com/codex/tasks/task_e_68c77c047b7c8329bfc7f31236d889e7