### PR TITLE
Enhance lidar point rasterization in UI

### DIFF
--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -11,6 +11,54 @@ angular.module('beamng.apps')
       // Fixed world range for drawing (in meters). Keeps zoom stable.
       var FIXED_RANGE = 60;
       var carColor = [255, 255, 255];
+      var ORTHOGONAL_OFFSETS = [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1]
+      ];
+      var DIAGONAL_OFFSETS = [
+        [1, 1],
+        [1, -1],
+        [-1, 1],
+        [-1, -1]
+      ];
+
+      function drawRasterizedPoint(x, y, color, size) {
+        if (!isFinite(size) || size <= 0) {
+          size = 2;
+        }
+
+        var primarySize = size;
+        var primaryHalf = primarySize * 0.5;
+        var neighborSpacing = Math.max(0.8, primarySize * 0.9);
+        var neighborSize = Math.max(0.6, primarySize * 0.75);
+        var diagSpacing = neighborSpacing * 1.35;
+        var diagSize = Math.max(0.45, primarySize * 0.55);
+
+        ctx.fillStyle = color;
+
+        ctx.globalAlpha = 0.85;
+        ctx.fillRect(x - primaryHalf, y - primaryHalf, primarySize, primarySize);
+
+        ctx.globalAlpha = 0.32;
+        for (var i = 0; i < ORTHOGONAL_OFFSETS.length; i++) {
+          var orth = ORTHOGONAL_OFFSETS[i];
+          var ox = x + orth[0] * neighborSpacing;
+          var oy = y + orth[1] * neighborSpacing;
+          ctx.fillRect(ox - neighborSize * 0.5, oy - neighborSize * 0.5, neighborSize, neighborSize);
+        }
+
+        ctx.globalAlpha = 0.18;
+        for (var j = 0; j < DIAGONAL_OFFSETS.length; j++) {
+          var diag = DIAGONAL_OFFSETS[j];
+          var dx = x + diag[0] * diagSpacing;
+          var dy = y + diag[1] * diagSpacing;
+          ctx.fillRect(dx - diagSize * 0.5, dy - diagSize * 0.5, diagSize, diagSize);
+        }
+
+        ctx.globalAlpha = 1;
+      }
 
       function drawVehicle() {
         ctx.save();
@@ -47,14 +95,21 @@ angular.module('beamng.apps')
         );
         var distRange = Math.max(1, maxD - minD);
 
+        var basePointSize = Math.max(2, Math.min(5, scale * 1.1));
+
         points.forEach(function (p) {
           var x = canvas.width / 2 + p.x * scale;
           var y = canvas.height / 2 - p.y * scale;
           var hue = ((p._d - minD) / distRange) * 240;
-          ctx.fillStyle = 'hsl(' + hue + ', 100%, 50%)';
-          ctx.fillRect(x, y, 2, 2);
+          var color = 'hsl(' + hue + ', 100%, 50%)';
+          var depthFactor = distRange > 0 ? 1 - (p._d - minD) / distRange : 0;
+          if (depthFactor < 0) { depthFactor = 0; }
+          if (depthFactor > 1) { depthFactor = 1; }
+          var pointSize = basePointSize + depthFactor * 1.2;
+          drawRasterizedPoint(x, y, color, pointSize);
         });
 
+        ctx.globalAlpha = 1;
         drawVehicle();
       }
 


### PR DESCRIPTION
## Summary
- add a rasterizing helper for lidar points to paint denser clusters with soft neighbors
- scale point size by canvas scale and distance to enrich both vehicle and scene detail in the lidar view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84627aaa083298dee150e03b8a9eb