### PR TITLE
Adjust vehicle lidar raster density to mimic point cloud

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -511,9 +511,9 @@ local function updateVirtualLidar(dt, veh)
         if s > VEHICLE_POINT_MAX_SPACING then return VEHICLE_POINT_MAX_SPACING end
         return s
       end
-      local baseSpacing = clampSpacing(2 * planarDist * sin(VIRTUAL_LIDAR_H_STEP * 0.5))
+      local baseSpacing = clampSpacing(2 * planarDist * math.sin(VIRTUAL_LIDAR_H_STEP * 0.5))
       local diagDist = math.sqrt(planarDist * planarDist + heightOffset * heightOffset)
-      local verticalSpacing = clampSpacing(2 * diagDist * sin(VIRTUAL_LIDAR_V_STEP * 0.5))
+      local verticalSpacing = clampSpacing(2 * diagDist * math.sin(VIRTUAL_LIDAR_V_STEP * 0.5))
       local spacingX = baseSpacing
       local spacingY = math.max(baseSpacing, verticalSpacing)
       local function stepsForHalfSpan(halfSpan, spacing)

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -22,8 +22,8 @@ angular.module('beamng.apps')
           Math.round(carColor[2]) + ',0.5)';
         var bounds = carBounds || DEFAULT_BOUNDS;
         var s = typeof scale === 'number' ? scale : 1;
-        var carWidth = bounds.width * 0.85 * s;
-        var carLength = bounds.length * 0.85 * s;
+        var carWidth = bounds.width * 1.50 * s;
+        var carLength = bounds.length * 1.20 * s;
         ctx.translate(canvas.width / 2, canvas.height / 2);
         ctx.fillRect(-carWidth / 2, -carLength / 2, carWidth, carLength);
         ctx.restore();

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -11,15 +11,19 @@ angular.module('beamng.apps')
       // Fixed world range for drawing (in meters). Keeps zoom stable.
       var FIXED_RANGE = 60;
       var carColor = [255, 255, 255];
+      var carBounds = null;
+      var DEFAULT_BOUNDS = { width: 2, length: 4 }; // meters
 
-      function drawVehicle() {
+      function drawVehicle(scale) {
         ctx.save();
         ctx.fillStyle = 'rgba(' +
           Math.round(carColor[0]) + ',' +
           Math.round(carColor[1]) + ',' +
           Math.round(carColor[2]) + ',0.5)';
-        var carWidth = 10 * 0.6;
-        var carLength = 20 * 0.6;
+        var bounds = carBounds || DEFAULT_BOUNDS;
+        var s = typeof scale === 'number' ? scale : 1;
+        var carWidth = bounds.width * 0.85 * s;
+        var carLength = bounds.length * 0.85 * s;
         ctx.translate(canvas.width / 2, canvas.height / 2);
         ctx.fillRect(-carWidth / 2, -carLength / 2, carWidth, carLength);
         ctx.restore();
@@ -27,8 +31,12 @@ angular.module('beamng.apps')
 
       function draw(points) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
+        var scale = Math.min(
+          canvas.width / (2 * FIXED_RANGE),
+          canvas.height / (2 * FIXED_RANGE)
+        );
         if (!points || !points.length) {
-          drawVehicle();
+          drawVehicle(scale);
           return;
         }
 
@@ -41,10 +49,6 @@ angular.module('beamng.apps')
           p._d = d;
         });
 
-        var scale = Math.min(
-          canvas.width / (2 * FIXED_RANGE),
-          canvas.height / (2 * FIXED_RANGE)
-        );
         var distRange = Math.max(1, maxD - minD);
 
         points.forEach(function (p) {
@@ -55,7 +59,7 @@ angular.module('beamng.apps')
           ctx.fillRect(x, y, 2, 2);
         });
 
-        drawVehicle();
+        drawVehicle(scale);
       }
 
       function update() {
@@ -70,13 +74,23 @@ angular.module('beamng.apps')
                   typeof data.color.b === 'number' ? data.color.b : 255
                 ];
               }
+              if (
+                data.bounds &&
+                typeof data.bounds.width === 'number' &&
+                typeof data.bounds.length === 'number'
+              ) {
+                carBounds = {
+                  width: data.bounds.width,
+                  length: data.bounds.length
+                };
+              }
               draw(data.points);
             });
           }
         );
       }
 
-      var interval = setInterval(update, 33);
+      var interval = setInterval(update, 100);
 
       $scope.$on('$destroy', function () {
         clearInterval(interval);

--- a/ui/modules/apps/virtualLidarApp/app.js
+++ b/ui/modules/apps/virtualLidarApp/app.js
@@ -18,8 +18,8 @@ angular.module('beamng.apps')
           Math.round(carColor[0]) + ',' +
           Math.round(carColor[1]) + ',' +
           Math.round(carColor[2]) + ',0.5)';
-        var carWidth = 10;
-        var carLength = 20;
+        var carWidth = 10 * 0.6;
+        var carLength = 20 * 0.6;
         ctx.translate(canvas.width / 2, canvas.height / 2);
         ctx.fillRect(-carWidth / 2, -carLength / 2, carWidth, carLength);
         ctx.restore();
@@ -76,7 +76,7 @@ angular.module('beamng.apps')
         );
       }
 
-      var interval = setInterval(update, 100);
+      var interval = setInterval(update, 33);
 
       $scope.$on('$destroy', function () {
         clearInterval(interval);


### PR DESCRIPTION
## Summary
- expose lidar geometry constants for reuse when building virtual lidar data
- compute vehicle raster spacing from lidar angles and distance so vehicles render as dot clouds instead of solid blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8768717d0832981b343b6887df04e