### PR TITLE
Fix busted tests by stubbing ghost check in sensor spec

### DIFF
--- a/.tests/sensor_system_spec.lua
+++ b/.tests/sensor_system_spec.lua
@@ -28,6 +28,9 @@ function extra_utils.getVehicleProperties(veh) return veh.props end
 function extra_utils.getCircularDistance(a, b) return (b.center_pos - a.center_pos):length() end
 function extra_utils.getWaypointStartEndAdvanced() return { start_wp_pos = vec(0,0,0), end_wp_pos = vec(1,0,0), wp_radius = 100 } end
 function extra_utils.checkIfOtherCarOnSameRoad() return true end
+function extra_utils.isVehicleGhost()
+  return false
+end
 
 package.loaded['scripts/driver_assistance_angelo234/extraUtils'] = extra_utils
 


### PR DESCRIPTION
## Summary
- add a stub implementation of `extra_utils.isVehicleGhost` in the sensor system spec so the mocked module matches the production API

## Testing
- busted

------
https://chatgpt.com/codex/tasks/task_e_68c88637572c8329b9e33881a60e802f