### PR TITLE
Limit lidar ray count to reduce scanning load

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -68,6 +68,8 @@ local VIRTUAL_LIDAR_H_FOV = math.rad(360)
 local VIRTUAL_LIDAR_V_FOV = math.rad(30)
 local VIRTUAL_LIDAR_H_RES = 60
 local VIRTUAL_LIDAR_V_RES = 15
+local VIRTUAL_LIDAR_MAX_RAYS = 80
+local FRONT_LIDAR_MAX_RAYS = 120
 local VIRTUAL_LIDAR_H_STEP = VIRTUAL_LIDAR_H_FOV / math.max(1, VIRTUAL_LIDAR_H_RES - 1)
 local VIRTUAL_LIDAR_V_STEP = VIRTUAL_LIDAR_V_FOV / math.max(1, VIRTUAL_LIDAR_V_RES - 1)
 local LIDAR_GROUND_THRESHOLD = -1.5
@@ -388,7 +390,11 @@ local function frontLidarLoop()
           15,
           0,
           veh:getID(),
-          {hStart = front_lidar_phase, hStep = FRONT_LIDAR_PHASES}
+          {
+            hStart = front_lidar_phase,
+            hStep = FRONT_LIDAR_PHASES,
+            maxRays = FRONT_LIDAR_MAX_RAYS
+          }
         )
         local groundThreshold = LIDAR_GROUND_THRESHOLD
         local lowObjectMin = groundThreshold - LIDAR_LOW_OBJECT_BAND
@@ -469,7 +475,11 @@ local function updateVirtualLidar(dt, veh)
       VIRTUAL_LIDAR_V_RES,
       0,
       veh:getID(),
-      {hStart = virtual_lidar_phase, hStep = VIRTUAL_LIDAR_PHASES}
+      {
+        hStart = virtual_lidar_phase,
+        hStep = VIRTUAL_LIDAR_PHASES,
+        maxRays = VIRTUAL_LIDAR_MAX_RAYS
+      }
     )
 
     -- cache properties of the player's vehicle for later filtering

--- a/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
+++ b/scripts/driver_assistance_angelo234/obstacleBrakingSystem.lua
@@ -6,6 +6,8 @@ local M = {}
 local extra_utils = require('scripts/driver_assistance_angelo234/extraUtils')
 local virtual_lidar = require('scripts/driver_assistance_angelo234/virtualLidar')
 
+local OBSTACLE_LIDAR_MAX_RAYS = 150
+
 -- system states: "ready", "braking", "holding"
 local system_state = "ready"
 local aeb_clear_timer = 0
@@ -58,7 +60,19 @@ local function frontObstacleDistance(veh, veh_props, aeb_params, speed, front_se
 
   local scan = {}
   if use_lidar then
-    scan = virtual_lidar.scan(origin, dir, up, maxDistance, math.rad(30), math.rad(20), 30, 10, 0, veh:getID())
+    scan = virtual_lidar.scan(
+      origin,
+      dir,
+      up,
+      maxDistance,
+      math.rad(30),
+      math.rad(20),
+      30,
+      10,
+      0,
+      veh:getID(),
+      {maxRays = OBSTACLE_LIDAR_MAX_RAYS}
+    )
     -- add points for nearby vehicles similar to sensor approach
     for i = 0, be:getObjectCount() - 1 do
       local other = be:getObject(i)

--- a/scripts/driver_assistance_angelo234/virtualLidar.lua
+++ b/scripts/driver_assistance_angelo234/virtualLidar.lua
@@ -10,7 +10,8 @@ local sin, cos = math.sin, math.cos
 -- maxDist: max scan distance
 -- hFov, vFov: horizontal and vertical field of view in radians
 -- ignoreId: optional vehicle id to exclude from results
--- opts: optional table {hStart, hStep, vStart, vStep} to scan only a subset of rays
+-- opts: optional table {hStart, hStep, vStart, vStep, maxRays, maxPoints}
+--       to scan only a subset of rays or clamp the total number processed
 local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, ignoreId, opts)
   local points = {}
   dir = dir:normalized()
@@ -23,17 +24,66 @@ local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, i
 
   opts = opts or {}
   local hStart = opts.hStart or 0
-  local hStep = opts.hStep or 1
+  local baseHStep = math.max(1, opts.hStep or 1)
   local vStart = opts.vStart or 0
-  local vStep = opts.vStep or 1
+  local baseVStep = math.max(1, opts.vStep or 1)
+  local maxRays = opts.maxRays and math.max(1, math.floor(opts.maxRays))
+  local maxPoints = opts.maxPoints and math.max(1, math.floor(opts.maxPoints))
+
+  local hStep = baseHStep
+  local vStep = baseVStep
+
+  if maxRays then
+    local function count(stepH, stepV)
+      local hCount = 0
+      local vCount = 0
+      if hRes > 0 and hStart <= (hRes - 1) then
+        hCount = math.floor(((hRes - 1) - hStart) / stepH) + 1
+      end
+      if vRes > 0 and vStart <= (vRes - 1) then
+        vCount = math.floor(((vRes - 1) - vStart) / stepV) + 1
+      end
+      if hCount == 0 or vCount == 0 then
+        return hCount, vCount, 0
+      end
+      return hCount, vCount, hCount * vCount
+    end
+    local _, _, total = count(hStep, vStep)
+    local guard = 0
+    while total > maxRays and guard < 64 do
+      local newVStep = vStep + baseVStep
+      local _, _, reduced = count(hStep, newVStep)
+      if reduced >= total then break end
+      vStep = newVStep
+      total = reduced
+      guard = guard + 1
+    end
+    guard = 0
+    while total > maxRays and guard < 64 do
+      local newHStep = hStep + baseHStep
+      local _, _, reduced = count(newHStep, vStep)
+      if reduced >= total then break end
+      hStep = newHStep
+      total = reduced
+      guard = guard + 1
+    end
+  end
+
+  local processed = 0
+  local stop = false
 
   for i = hStart, hRes - 1, hStep do
     local hAng = -hFov * 0.5 + hFov * i / math.max(1, hRes - 1)
     local ch, sh = cos(hAng), sin(hAng)
     for j = vStart, vRes - 1, vStep do
+      if maxRays and processed >= maxRays then
+        stop = true
+        break
+      end
       local vAng = -vFov * 0.5 + vFov * j / math.max(1, vRes - 1)
       local cv, sv = cos(vAng), sin(vAng)
       local rayDir = dir * (cv * ch) + right * (cv * sh) + up * sv
+      processed = processed + 1
       -- Perform both static and dynamic raycasts and keep the closest hit.
       local staticDist = castRayStatic(origin, rayDir, maxDist)
       local dynHit = castRay(origin, origin + rayDir * maxDist, true, true)
@@ -58,8 +108,13 @@ local function scan(origin, dir, up, maxDist, hFov, vFov, hRes, vRes, minDist, i
 
       if pt and dist and dist >= minDist then
         points[#points + 1] = pt
+        if maxPoints and #points >= maxPoints then
+          stop = true
+          break
+        end
       end
     end
+    if stop then break end
   end
   return points
 end


### PR DESCRIPTION
## Summary
- add support for limiting the number of rays processed by the shared virtual lidar scan helper
- cap the virtual and front lidar updates to lower per-frame ray budgets to keep point clouds lighter
- reduce the obstacle braking lidar scan density to avoid excessive casts in cluttered scenes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c89e7f3c948329b4b0079b28346442