### PR TITLE
Add virtual LiDAR PCD streaming support

### DIFF
--- a/.tests/lidar_pcd_stream_server_test.lua
+++ b/.tests/lidar_pcd_stream_server_test.lua
@@ -1,0 +1,257 @@
+local laura = require('laura')
+local describe = laura.describe
+local it = laura.it
+local expect = laura.expect
+local hooks = laura.hooks
+
+local original_socket_module = package.loaded['socket']
+local original_socket_preload = package.preload['socket']
+local original_logger_module = package.loaded['scripts/driver_assistance_angelo234/logger']
+
+local function makeClientStub(options)
+  options = options or {}
+  local client = {
+    sends = {},
+    closed = false,
+    setoptionCalls = {},
+  }
+
+  function client:settimeout(value)
+    self.timeout = value
+  end
+
+  if options.disableSetOption ~= true then
+    function client:setoption(opt, value)
+      self.setoptionCalls[#self.setoptionCalls + 1] = { opt = opt, value = value }
+      if options.failSetOption then
+        error('setoption failure')
+      end
+      return true
+    end
+  end
+
+  function client:send(data, index)
+    local chunk = data
+    if index and index > 1 then
+      chunk = data:sub(index)
+    end
+    self.sends[#self.sends + 1] = chunk
+    if options.failOnSend then
+      return nil, options.failOnSend
+    end
+    return #data
+  end
+
+  function client:close()
+    self.closed = true
+  end
+
+  return client
+end
+
+local function makeServerStub()
+  local server = {
+    acceptQueue = {},
+    closed = false,
+  }
+
+  function server:settimeout(value)
+    self.timeout = value
+  end
+
+  function server:accept()
+    if #self.acceptQueue == 0 then
+      return nil, 'timeout'
+    end
+
+    local nextItem = table.remove(self.acceptQueue, 1)
+    if type(nextItem) == 'table' and nextItem.error then
+      return nil, nextItem.error
+    end
+
+    return nextItem
+  end
+
+  function server:close()
+    self.closed = true
+  end
+
+  return server
+end
+
+local function makeFakeSocket()
+  local stub = {
+    binds = {},
+    nextServer = nil,
+    failNextBind = false,
+    nextError = 'bind failed',
+  }
+
+  function stub.bind(host, port)
+    stub.binds[#stub.binds + 1] = { host = host, port = port }
+    if stub.failNextBind then
+      stub.failNextBind = false
+      return nil, stub.nextError
+    end
+
+    local server = stub.nextServer or makeServerStub()
+    stub.nextServer = nil
+    stub.lastServer = server
+    server.boundHost = host
+    server.boundPort = port
+    return server
+  end
+
+  return stub
+end
+
+describe('lidarPcdStreamServer', function()
+  local fakeSocket
+  local logs
+  local moduleUnderTest
+
+  local function loadModule()
+    package.loaded['scripts/driver_assistance_angelo234/lidarPcdStreamServer'] = nil
+    moduleUnderTest = require('scripts/driver_assistance_angelo234/lidarPcdStreamServer')
+    return moduleUnderTest
+  end
+
+  hooks.beforeEach(function()
+    logs = {}
+    fakeSocket = makeFakeSocket()
+
+    package.loaded['socket'] = nil
+    package.preload['socket'] = function()
+      return fakeSocket
+    end
+
+    local loggerStub = {}
+    function loggerStub.log(level, tag, message)
+      logs[#logs + 1] = { level = level, tag = tag, message = message }
+    end
+    package.loaded['scripts/driver_assistance_angelo234/logger'] = loggerStub
+
+    package.loaded['scripts/driver_assistance_angelo234/lidarPcdStreamServer'] = nil
+    moduleUnderTest = nil
+  end)
+
+  hooks.afterEach(function()
+    if moduleUnderTest and moduleUnderTest.stop then
+      moduleUnderTest.stop()
+    end
+    package.loaded['scripts/driver_assistance_angelo234/lidarPcdStreamServer'] = nil
+    package.loaded['socket'] = original_socket_module
+    package.preload['socket'] = original_socket_preload
+    package.loaded['scripts/driver_assistance_angelo234/logger'] = original_logger_module
+  end)
+
+  it('accepts clients and broadcasts PCD payloads with headers', function()
+    local serverStub = makeServerStub()
+    local clientA = makeClientStub()
+    local clientB = makeClientStub()
+    serverStub.acceptQueue = { clientA, clientB }
+    fakeSocket.nextServer = serverStub
+
+    local server = loadModule()
+    local ok = server.start('127.0.0.1', 8765)
+    expect(ok).toBeTruthy()
+
+    server.update(0.0)
+    expect(server.clientCount()).toEqual(2)
+    expect(clientA.timeout).toEqual(0)
+    expect(clientB.timeout).toEqual(0)
+    expect(#clientA.setoptionCalls).toEqual(1)
+    expect(clientA.setoptionCalls[1].opt).toEqual('tcp-nodelay')
+
+    local payload = 'ABCD'
+    server.broadcast(payload)
+
+    expect(clientA.sends).toEqual({ 'PCD 4\n', payload })
+    expect(clientB.sends).toEqual({ 'PCD 4\n', payload })
+  end)
+
+  it('removes clients that fail to send payloads', function()
+    local serverStub = makeServerStub()
+    local healthyClient = makeClientStub()
+    local failingClient = makeClientStub({ failOnSend = 'closed' })
+    serverStub.acceptQueue = { healthyClient, failingClient }
+    fakeSocket.nextServer = serverStub
+
+    local server = loadModule()
+    expect(server.start('127.0.0.1', 9000)).toBeTruthy()
+
+    server.update(0.0)
+    expect(server.clientCount()).toEqual(2)
+
+    server.broadcast('HELLO')
+
+    expect(server.clientCount()).toEqual(1)
+    expect(healthyClient.closed).toBeFalsy()
+    expect(failingClient.closed).toBeTruthy()
+    expect(healthyClient.sends).toEqual({ 'PCD 5\n', 'HELLO' })
+  end)
+
+  it('sends heartbeat messages at the configured interval', function()
+    local serverStub = makeServerStub()
+    local client = makeClientStub()
+    serverStub.acceptQueue = { client }
+    fakeSocket.nextServer = serverStub
+
+    local server = loadModule()
+    expect(server.start('127.0.0.1', 7000)).toBeTruthy()
+
+    server.setHeartbeatInterval(0.25)
+
+    server.update(0.0) -- accept the pending client
+    expect(server.clientCount()).toEqual(1)
+
+    server.update(0.2)
+    expect(#client.sends).toEqual(0)
+
+    server.update(0.1)
+    expect(client.sends).toEqual({ 'PING\n' })
+
+    server.update(0.25)
+    expect(client.sends).toEqual({ 'PING\n', 'PING\n' })
+  end)
+
+  it('stops the server and closes all clients', function()
+    local serverStub = makeServerStub()
+    local clientA = makeClientStub()
+    local clientB = makeClientStub()
+    serverStub.acceptQueue = { clientA, clientB }
+    fakeSocket.nextServer = serverStub
+
+    local server = loadModule()
+    expect(server.start('127.0.0.1', 8800)).toBeTruthy()
+
+    server.update(0.0)
+    expect(server.clientCount()).toEqual(2)
+
+    server.stop()
+
+    expect(server.isRunning()).toBeFalsy()
+    expect(server.clientCount()).toEqual(0)
+    expect(serverStub.closed).toBeTruthy()
+    expect(clientA.closed).toBeTruthy()
+    expect(clientB.closed).toBeTruthy()
+  end)
+
+  it('logs an error when the server fails to bind', function()
+    fakeSocket.failNextBind = true
+    fakeSocket.nextError = 'address in use'
+
+    local server = loadModule()
+    local ok, err = server.start('127.0.0.1', 9100)
+
+    expect(ok).toBeFalsy()
+    expect(err).toEqual('address in use')
+    expect(server.isRunning()).toBeFalsy()
+    expect(#logs).toEqual(1)
+    expect(logs[0]).toBeNil()
+    expect(logs[1].level).toEqual('E')
+    expect(logs[1].tag).toEqual('lidar')
+    expect(string.find(logs[1].message, 'address in use', 1, true)).toBeTruthy()
+  end)
+end)
+

--- a/.tests/lidar_pcd_stream_server_test.lua
+++ b/.tests/lidar_pcd_stream_server_test.lua
@@ -166,8 +166,8 @@ describe('lidarPcdStreamServer', function()
     local payload = 'ABCD'
     server.broadcast(payload)
 
-    expect(clientA.sends).toEqual({ 'PCD 4\n', payload })
-    expect(clientB.sends).toEqual({ 'PCD 4\n', payload })
+    expect(clientA.sends).toDeepEqual({ 'PCD 4\n', payload })
+    expect(clientB.sends).toDeepEqual({ 'PCD 4\n', payload })
   end)
 
   it('removes clients that fail to send payloads', function()
@@ -188,7 +188,7 @@ describe('lidarPcdStreamServer', function()
     expect(server.clientCount()).toEqual(1)
     expect(healthyClient.closed).toBeFalsy()
     expect(failingClient.closed).toBeTruthy()
-    expect(healthyClient.sends).toEqual({ 'PCD 5\n', 'HELLO' })
+    expect(healthyClient.sends).toDeepEqual({ 'PCD 5\n', 'HELLO' })
   end)
 
   it('sends heartbeat messages at the configured interval', function()
@@ -209,10 +209,10 @@ describe('lidarPcdStreamServer', function()
     expect(#client.sends).toEqual(0)
 
     server.update(0.1)
-    expect(client.sends).toEqual({ 'PING\n' })
+    expect(client.sends).toDeepEqual({ 'PING\n' })
 
     server.update(0.25)
-    expect(client.sends).toEqual({ 'PING\n', 'PING\n' })
+    expect(client.sends).toDeepEqual({ 'PING\n', 'PING\n' })
   end)
 
   it('stops the server and closes all clients', function()

--- a/scripts/driver_assistance_angelo234/lidarPcdPublisher.lua
+++ b/scripts/driver_assistance_angelo234/lidarPcdPublisher.lua
@@ -82,6 +82,80 @@ end
 
 local M = {}
 
+local packPoint
+
+do
+  local hasStringPack = type(string.pack) == 'function'
+
+  if hasStringPack then
+    packPoint = function(x, y, z, intensity)
+      return string.pack('<ffff', x, y, z, intensity)
+    end
+  else
+    local function encodeFloat(value)
+      if value ~= value then
+        return 0xffc00000
+      end
+      if value == math.huge then
+        return 0x7f800000
+      end
+      if value == -math.huge then
+        return 0xff800000
+      end
+
+      local sign = 0
+      if value < 0 or (value == 0 and 1 / value < 0) then
+        sign = 0x80000000
+        value = -value
+      end
+
+      if value == 0 then
+        return sign
+      end
+
+      local mantissa, exponent = math.frexp(value)
+      exponent = exponent - 1
+      mantissa = mantissa * 2 - 1
+      exponent = exponent + 127
+
+      if exponent <= 0 then
+        mantissa = math.floor((mantissa + 1) * math.ldexp(1, exponent + 22) + 0.5)
+        exponent = 0
+      else
+        mantissa = math.floor(mantissa * 0x800000 + 0.5)
+      end
+
+      if mantissa == 0x800000 then
+        exponent = exponent + 1
+        mantissa = 0
+      end
+
+      if exponent >= 255 then
+        exponent = 255
+        mantissa = 0
+      end
+
+      return sign + exponent * 0x800000 + mantissa
+    end
+
+    local function packFloat(value)
+      local bits = encodeFloat(value)
+      local b1 = bits % 256
+      bits = (bits - b1) / 256
+      local b2 = bits % 256
+      bits = (bits - b2) / 256
+      local b3 = bits % 256
+      bits = (bits - b3) / 256
+      local b4 = bits % 256
+      return string.char(b1, b2, b3, b4)
+    end
+
+    packPoint = function(x, y, z, intensity)
+      return packFloat(x) .. packFloat(y) .. packFloat(z) .. packFloat(intensity)
+    end
+  end
+end
+
 local function computeDefaultPath()
   if FS and FS.getUserPath then
     local ok, base = pcall(function()
@@ -152,7 +226,7 @@ local function appendPoints(segments, points, intensity)
       local x = pt.x or pt[1] or 0
       local y = pt.y or pt[2] or 0
       local z = pt.z or pt[3] or 0
-      segments[#segments + 1] = string.pack('<fff f', x, y, z, intensity)
+      segments[#segments + 1] = packPoint(x, y, z, intensity)
       count = count + 1
     end
   end

--- a/scripts/driver_assistance_angelo234/lidarPcdStreamServer.lua
+++ b/scripts/driver_assistance_angelo234/lidarPcdStreamServer.lua
@@ -1,0 +1,180 @@
+-- This Source Code Form is subject to the terms of the bCDDL, v. 1.1.
+-- If a copy of the bCDDL was not distributed with this
+-- file, You can obtain one at http://beamng.com/bCDDL-1.1.txt
+
+local socket = require('socket')
+
+local logger = require('scripts/driver_assistance_angelo234/logger')
+
+local M = {}
+
+local state = {
+  server = nil,
+  host = '127.0.0.1',
+  port = nil,
+  clients = {},
+  heartbeatInterval = 1.0,
+  heartbeatTimer = 0
+}
+
+local function logError(message)
+  logger.log('E', 'lidar', message)
+  if ui_message then
+    ui_message(message)
+  end
+end
+
+local function closeClient(client)
+  if not client then return end
+  local ok, err = pcall(function()
+    client:close()
+  end)
+  if not ok and err then
+    logger.log('E', 'lidar', string.format('Failed to close client: %s', tostring(err)))
+  end
+end
+
+local function clearClients()
+  for i = #state.clients, 1, -1 do
+    closeClient(state.clients[i])
+    state.clients[i] = nil
+  end
+end
+
+local function stopServer()
+  if state.server then
+    local ok, err = pcall(function()
+      state.server:close()
+    end)
+    if not ok and err then
+      logger.log('E', 'lidar', string.format('Failed to close LiDAR stream server: %s', tostring(err)))
+    end
+  end
+  state.server = nil
+end
+
+function M.stop()
+  clearClients()
+  stopServer()
+  state.heartbeatTimer = 0
+end
+
+local function sendAll(client, data)
+  if not client or not data or data == '' then return true end
+  local totalSent = 0
+  local totalSize = #data
+  while totalSent < totalSize do
+    local sent, err, partial = client:send(data, totalSent + 1)
+    if not sent then
+      if err == 'timeout' then
+        if partial and partial > totalSent then
+          totalSent = partial
+        else
+          return false, err
+        end
+      else
+        return false, err
+      end
+    else
+      totalSent = sent
+    end
+  end
+  return true
+end
+
+local function removeClient(index)
+  local client = state.clients[index]
+  if client then
+    closeClient(client)
+  end
+  table.remove(state.clients, index)
+end
+
+local function broadcastRaw(data)
+  if not data or data == '' then return end
+  for i = #state.clients, 1, -1 do
+    local client = state.clients[i]
+    local ok = sendAll(client, data)
+    if not ok then
+      removeClient(i)
+    end
+  end
+end
+
+local function acceptClients()
+  if not state.server then return end
+  while true do
+    local client, err = state.server:accept()
+    if not client then
+      if err and err ~= 'timeout' and err ~= 'wantread' then
+        logger.log('E', 'lidar', string.format('LiDAR PCD stream accept error: %s', tostring(err)))
+      end
+      break
+    end
+    client:settimeout(0)
+    if client.setoption then
+      pcall(client.setoption, client, 'tcp-nodelay', true)
+    end
+    state.clients[#state.clients + 1] = client
+  end
+end
+
+function M.start(host, port)
+  host = host or state.host or '127.0.0.1'
+  local server, err = socket.bind(host, port)
+  if not server then
+    logError(string.format('Failed to start LiDAR PCD stream on %s:%s (%s)', tostring(host), tostring(port), tostring(err)))
+    return false, err
+  end
+  server:settimeout(0)
+  M.stop()
+  state.server = server
+  state.host = host
+  state.port = port
+  state.clients = {}
+  state.heartbeatTimer = 0
+  return true
+end
+
+function M.update(dt)
+  if not state.server then return end
+  acceptClients()
+  state.heartbeatTimer = state.heartbeatTimer + (dt or 0)
+  if state.heartbeatTimer >= state.heartbeatInterval then
+    state.heartbeatTimer = state.heartbeatTimer - state.heartbeatInterval
+    if #state.clients > 0 then
+      broadcastRaw('PING\n')
+    end
+  end
+end
+
+function M.broadcast(pcdBytes)
+  if not state.server or not pcdBytes or pcdBytes == '' then return end
+  local header = string.format('PCD %d\n', #pcdBytes)
+  for i = #state.clients, 1, -1 do
+    local client = state.clients[i]
+    local ok = sendAll(client, header)
+    if ok then
+      ok = sendAll(client, pcdBytes)
+    end
+    if not ok then
+      removeClient(i)
+    end
+  end
+end
+
+function M.setHeartbeatInterval(interval)
+  if type(interval) == 'number' and interval > 0 then
+    state.heartbeatInterval = interval
+  end
+end
+
+function M.clientCount()
+  return #state.clients
+end
+
+function M.isRunning()
+  return state.server ~= nil
+end
+
+return M

--- a/scripts/driver_assistance_angelo234/tools/testPcdStream.lua
+++ b/scripts/driver_assistance_angelo234/tools/testPcdStream.lua
@@ -1,0 +1,88 @@
+-- This Source Code Form is subject to the terms of the bCDDL, v. 1.1.
+-- If a copy of the bCDDL was not distributed with this
+-- file, You can obtain one at http://beamng.com/bCDDL-1.1.txt
+
+local socket = require('socket')
+
+local M = {}
+
+local function receiveExact(client, expected)
+  local parts = {}
+  local received = 0
+  while received < expected do
+    local chunk, err, partial = client:receive(expected - received)
+    if chunk then
+      parts[#parts + 1] = chunk
+      received = received + #chunk
+    elseif err == 'timeout' then
+      if partial and #partial > 0 then
+        parts[#parts + 1] = partial
+        received = received + #partial
+      else
+        socket.sleep(0.05)
+      end
+    else
+      return nil, err
+    end
+  end
+  return table.concat(parts)
+end
+
+function M.run(host, port, duration)
+  host = host or '127.0.0.1'
+  port = tonumber(port) or 8765
+  duration = duration or 5
+
+  local client, err = socket.tcp()
+  if not client then
+    return nil, 'failed to create socket: ' .. tostring(err)
+  end
+
+  local ok, connectErr = client:connect(host, port)
+  if not ok then
+    return nil, 'failed to connect: ' .. tostring(connectErr)
+  end
+
+  client:settimeout(0)
+
+  local deadline = socket.gettime() + duration
+  local stats = {pcd = 0, heartbeat = 0}
+
+  while socket.gettime() < deadline do
+    local line, err = client:receive('*l')
+    if line then
+      if line:sub(1, 3) == 'PCD' then
+        local size = tonumber(line:match('PCD%s+(%d+)')) or 0
+        if size > 0 then
+          local payload, perr = receiveExact(client, size)
+          if payload then
+            stats.pcd = stats.pcd + 1
+            print(string.format('Received PCD payload (%d bytes)', #payload))
+          else
+            print('Failed to receive PCD payload: ' .. tostring(perr))
+            break
+          end
+        else
+          print('Received empty PCD payload')
+        end
+      elseif line == 'PING' then
+        stats.heartbeat = stats.heartbeat + 1
+        print('Heartbeat received')
+      else
+        print('Unknown message: ' .. line)
+      end
+    else
+      if err == 'timeout' then
+        socket.sleep(0.05)
+      else
+        print('Connection closed: ' .. tostring(err))
+        break
+      end
+    end
+  end
+
+  client:close()
+  return stats
+end
+
+return M


### PR DESCRIPTION
## Summary
- add a non-blocking LiDAR PCD streaming server with heartbeat support
- hook the streaming server into the driver assistance extension and expose controls to enable it and change the port
- update the PCD publisher to return binary payloads for streaming and add a console test helper

## Testing
- `lua -p scripts/driver_assistance_angelo234/extension.lua` *(fails: lua interpreter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb5aae7648329a389fac14cee74a8