### PR TITLE
Guard lane centering activation hook

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -1327,7 +1327,9 @@ local function onExtensionUnloaded()
   stopVirtualLidarStreamServer()
 end
 
-lane_centering_system.setActivationCallback(handleLaneCenteringActivationRequest)
+if lane_centering_system and lane_centering_system.setActivationCallback then
+  lane_centering_system.setActivationCallback(handleLaneCenteringActivationRequest)
+end
 
 M.onExtensionLoaded = onExtensionLoaded
 M.onVehicleSwitched = onVehicleSwitched


### PR DESCRIPTION
## Summary
- guard the lane centering activation callback registration so the extension loads even when tests stub the module without the hook

## Testing
- lua .scripts/run_laura_tests.lua spec reports/laura.xml reports/laura_summary.json

------
https://chatgpt.com/codex/tasks/task_e_68cdddcd602483298808aad075dcecc1