### PR TITLE
Fix missing driver assistance global reference

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -10,6 +10,15 @@ veh_accs_angelo234 = {}
 
 local M = {}
 
+-- Expose the extension instance through the legacy global name that other
+-- driver assistance modules expect. Some modules (such as the forward
+-- collision mitigation system) reference
+-- `scripts_driver__assistance__angelo234_extension` directly and crash if it
+-- is missing.  When the extension is loaded we immediately publish the module
+-- table under that global so that dependent modules can safely call back into
+-- the extension without needing to guard against a missing reference.
+rawset(_G, 'scripts_driver__assistance__angelo234_extension', M)
+
 local extra_utils = require('scripts/driver_assistance_angelo234/extraUtils')
 
 local sensor_system = require('scripts/driver_assistance_angelo234/sensorSystem')

--- a/scripts/driver_assistance_angelo234/forwardCollisionMitigationSystem.lua
+++ b/scripts/driver_assistance_angelo234/forwardCollisionMitigationSystem.lua
@@ -174,6 +174,24 @@ end
 
 local release_brake_confidence_level = 0
 
+local function disableAdaptiveCruiseControl()
+  local extension = rawget(_G, 'scripts_driver__assistance__angelo234_extension')
+  if not extension then return end
+
+  local setter = extension.setACCSystemOn
+  if type(setter) ~= 'function' then return end
+
+  local ok, err = pcall(setter, false)
+  if not ok then
+    local msg = string.format('Failed to disable ACC: %s', tostring(err))
+    if log then
+      log('E', 'fcm', msg)
+    else
+      print('[fcm] ' .. msg)
+    end
+  end
+end
+
 local function performEmergencyBraking(dt, veh, aeb_params, time_before_braking, speed)
   --If throttle or brake is highly requested then override braking
   if input_throttle_angelo234 > 0.5 or input_brake_angelo234 > 0.3 then
@@ -201,7 +219,7 @@ local function performEmergencyBraking(dt, veh, aeb_params, time_before_braking,
     veh:queueLuaCommand("electrics.values.brakeOverride = 1")
 
     --Turn off Adaptive Cruise Control
-    scripts_driver__assistance__angelo234_extension.setACCSystemOn(false)
+    disableAdaptiveCruiseControl()
 
     system_state = "braking"
 


### PR DESCRIPTION
## Summary
- expose the driver assistance extension module through its legacy global name so dependent systems can call into it without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce04611910832996daa33b4c4c215a