### PR TITLE
Integrate AI steering control for lane centering

### DIFF
--- a/scripts/driver_assistance_angelo234/accSystem.lua
+++ b/scripts/driver_assistance_angelo234/accSystem.lua
@@ -309,10 +309,15 @@ local function update(dt, veh, system_params, aeb_params, front_sensor_data)
   end
 end
 
+local function getCurrentTargetSpeed()
+  return target_speed, ramped_target_speed
+end
+
 M.onToggled = onToggled
 M.setACCSpeed = setACCSpeed
 M.changeACCSpeed = changeACCSpeed
 M.changeACCFollowingDistance = changeACCFollowingDistance
 M.update = update
+M.getCurrentTargetSpeed = getCurrentTargetSpeed
 
 return M

--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -342,6 +342,19 @@ end
 
 local lane_centering_ai_manual_enable_command = [[
     if ai then
+      local prevEnableElectrics = true
+      if ai.getParameters then
+        local params = ai.getParameters()
+        if params and params.enableElectrics ~= nil then
+          prevEnableElectrics = params.enableElectrics and true or false
+        end
+      end
+      if laneCenteringPrevEnableElectrics == nil then
+        laneCenteringPrevEnableElectrics = prevEnableElectrics
+      end
+      if ai.setParameters then
+        ai.setParameters({enableElectrics = false})
+      end
       ai.setState({mode='traffic', manoeuvre=false})
       ai.setSpeedMode('set')
       ai.driveInLane('on')
@@ -361,6 +374,9 @@ local lane_centering_ai_manual_enable_command = [[
 
 local lane_centering_ai_manual_refresh_command = [[
     if ai then
+      if ai.setParameters then
+        ai.setParameters({enableElectrics = false})
+      end
       ai.setSpeedMode('set')
       ai.driveInLane('on')
       ai.setAvoidCars('off')
@@ -373,6 +389,19 @@ local lane_centering_ai_manual_refresh_command = [[
 
 local lane_centering_ai_speed_enable_template = [[
     if ai then
+      local prevEnableElectrics = true
+      if ai.getParameters then
+        local params = ai.getParameters()
+        if params and params.enableElectrics ~= nil then
+          prevEnableElectrics = params.enableElectrics and true or false
+        end
+      end
+      if laneCenteringPrevEnableElectrics == nil then
+        laneCenteringPrevEnableElectrics = prevEnableElectrics
+      end
+      if ai.setParameters then
+        ai.setParameters({enableElectrics = false})
+      end
       ai.setState({mode='traffic', manoeuvre=false})
       ai.setSpeedMode('set')
       ai.driveInLane('on')
@@ -393,6 +422,9 @@ local lane_centering_ai_speed_enable_template = [[
 
 local lane_centering_ai_speed_refresh_template = [[
     if ai then
+      if ai.setParameters then
+        ai.setParameters({enableElectrics = false})
+      end
       ai.setSpeedMode('set')
       ai.driveInLane('on')
       ai.setAvoidCars('off')
@@ -422,7 +454,15 @@ end
 
 local function queueLaneCenteringAiDisable(veh)
   local command = [[
+    local prevEnableElectrics = laneCenteringPrevEnableElectrics
+    laneCenteringPrevEnableElectrics = nil
     if ai then
+      if prevEnableElectrics == nil then
+        prevEnableElectrics = true
+      end
+      if ai.setParameters then
+        ai.setParameters({enableElectrics = prevEnableElectrics and true or false})
+      end
       ai.setSpeed(0)
       ai.setSpeedMode('set')
       ai.driveInLane('off')

--- a/scripts/driver_assistance_angelo234/laneCenteringAssistSystem.lua
+++ b/scripts/driver_assistance_angelo234/laneCenteringAssistSystem.lua
@@ -1105,7 +1105,8 @@ local function update(dt, veh, system_params, enabled)
     active = false,
     available = false,
     reason = nil,
-    driverOverride = false
+    driverOverride = false,
+    aiTrafficControlsSpeed = false
   }
 
   if not installed then
@@ -1170,6 +1171,7 @@ local function update(dt, veh, system_params, enabled)
   end
 
   local ai_mode_active = rawget(_G, "lane_centering_ai_mode_active_angelo234") and true or false
+  local ai_speed_control_active = rawget(_G, "lane_centering_ai_speed_control_active_angelo234") and true or false
   local assist_ready = user_enabled and lane_model ~= nil and forward_speed > min_active_speed and override_timer <= 0
 
   local override_value = driver_axis ~= nil and clamp(driver_axis, -1, 1) or driver_input
@@ -1252,7 +1254,9 @@ local function update(dt, veh, system_params, enabled)
 
   assist_info.driverOverride = status.driverOverride
   assist_info.aiTrafficActive = ai_mode_active
+  assist_info.aiTrafficControlsSpeed = ai_speed_control_active
   status.aiTrafficActive = ai_mode_active
+  status.aiTrafficControlsSpeed = ai_speed_control_active
 
   latest_data = {
     status = status,

--- a/scripts/driver_assistance_angelo234/laneCenteringAssistSystem.lua
+++ b/scripts/driver_assistance_angelo234/laneCenteringAssistSystem.lua
@@ -1143,8 +1143,8 @@ local function update(dt, veh, system_params, enabled)
   local forward_speed = veh_props.velocity:dot(veh_props.dir)
   local user_enabled = status.enabled
 
-  local driver_input = rawget(_G, "input_steering_driver_angelo234")
-    or rawget(_G, "input_steering_angelo234")
+  local driver_axis = rawget(_G, "input_steering_driver_angelo234")
+  local driver_input = driver_axis or rawget(_G, "input_steering_angelo234")
   if driver_input == nil then
     local estimated = 0
     if electrics_values_angelo234 then
@@ -1169,9 +1169,11 @@ local function update(dt, veh, system_params, enabled)
     status.reason = status.reason or "no_lane_data"
   end
 
+  local ai_mode_active = rawget(_G, "lane_centering_ai_mode_active_angelo234") and true or false
   local assist_ready = user_enabled and lane_model ~= nil and forward_speed > min_active_speed and override_timer <= 0
 
-  if assist_ready and abs(driver_input) > disable_threshold then
+  local override_value = driver_axis ~= nil and clamp(driver_axis, -1, 1) or driver_input
+  if assist_ready and abs(override_value) > disable_threshold then
     status.driverOverride = true
     status.reason = "driver_override"
     assist_ready = false
@@ -1203,12 +1205,9 @@ local function update(dt, veh, system_params, enabled)
     local blended = target * assist_weight
     local final = clamp(driver_input + blended, -1, 1)
 
-    last_assist_delta = final - driver_input
+    local applied_delta = final - driver_input
 
-    veh:queueLuaCommand(string.format(
-      "input.event('steering', %f, 'FILTER_LANE_CENTERING', nil, nil, nil, 'lane_centering')",
-      final
-    ))
+    last_assist_delta = 0
 
     assist_info.active = true
     assist_info.steering.target = target
@@ -1219,7 +1218,7 @@ local function update(dt, veh, system_params, enabled)
     assist_info.steering.error = norm_error
     assist_info.steering.headingError = heading_error
     assist_info.steering.curvature = lane_model.curvature or 0
-    assist_info.steering.applied = last_assist_delta
+    assist_info.steering.applied = applied_delta
 
     status.active = true
     status.reason = nil
@@ -1252,6 +1251,8 @@ local function update(dt, veh, system_params, enabled)
   end
 
   assist_info.driverOverride = status.driverOverride
+  assist_info.aiTrafficActive = ai_mode_active
+  status.aiTrafficActive = ai_mode_active
 
   latest_data = {
     status = status,


### PR DESCRIPTION
## Summary
- expose the adaptive cruise control target speed so other systems can reuse it
- drive lane centering engagement through the vehicle AI traffic mode with refreshed speed and input source overrides
- stop injecting steering inputs manually, monitor driver overrides, and report the AI steering status for the UI

## Testing
- not run (lua interpreter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf1bdb2ddc8329975cbec06d39b519