### PR TITLE
Refine lane centering assist layout

### DIFF
--- a/ui/modules/apps/laneCenteringAssistApp/app.html
+++ b/ui/modules/apps/laneCenteringAssistApp/app.html
@@ -1,29 +1,34 @@
 <div class="bngApp lca-container" layout="column">
   <style>
     .lca-container {
-      --lca-scale: 1;
+      --lca-scale: clamp(0.75, calc(0.85 + (100vw - 720px) / 1600), 1.15);
       box-sizing: border-box;
       color: #f0f0f0;
       font-family: 'Roboto', sans-serif;
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: minmax(260px, 1fr) minmax(320px, 1.1fr);
+      grid-template-rows: auto minmax(0, 1fr);
+      grid-template-areas:
+        "header visual"
+        "info visual";
       height: 100%;
-      gap: 8px;
-      gap: calc(8px * var(--lca-scale));
-      padding: 10px;
-      padding: calc(10px * var(--lca-scale));
-      font-size: 14px;
-      font-size: calc(14px * var(--lca-scale));
+      min-width: 0;
+      min-height: 0;
+      gap: 12px;
+      gap: calc(12px * var(--lca-scale));
+      padding: 12px;
+      padding: calc(12px * var(--lca-scale));
+      font-size: clamp(12px, calc(12px + 0.2vw), 16px);
       line-height: 1.4;
     }
 
     .lca-header {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
+      grid-area: header;
+      display: grid;
+      grid-template-columns: minmax(150px, auto) 1fr;
       align-items: flex-start;
-      gap: 10px;
-      gap: calc(10px * var(--lca-scale));
+      gap: 12px;
+      gap: calc(12px * var(--lca-scale));
     }
 
     .lca-status {
@@ -51,29 +56,32 @@
     }
 
     .lca-header-metrics {
-      flex: 1 1 220px;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 8px;
-      gap: calc(8px * var(--lca-scale));
-      font-size: 0.88em;
-      opacity: 0.88;
-      text-align: right;
-      align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px;
+      gap: calc(10px * var(--lca-scale));
+      font-size: 0.9em;
+      opacity: 0.9;
+      text-align: left;
+      align-content: start;
     }
 
     .lca-visual {
+      grid-area: visual;
       position: relative;
-      width: 100%;
-      flex: 1 1 auto;
-      min-height: 200px;
-      min-height: calc(200px * var(--lca-scale));
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+      min-height: clamp(180px, calc(220px * var(--lca-scale)), 360px);
+      min-width: 0;
     }
 
     .lca-visual canvas {
       display: block;
       width: 100%;
       height: auto;
+      max-height: 100%;
+      aspect-ratio: 4 / 3;
       border-radius: 8px;
       border-radius: calc(8px * var(--lca-scale));
       background: rgba(0, 0, 0, 0.35);
@@ -82,18 +90,51 @@
     }
 
     .lca-info {
+      grid-area: info;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 6px 14px;
-      gap: calc(6px * var(--lca-scale)) calc(14px * var(--lca-scale));
-      font-size: 0.88em;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 8px 16px;
+      gap: calc(8px * var(--lca-scale)) calc(16px * var(--lca-scale));
+      font-size: 0.9em;
       opacity: 0.92;
+      min-height: 0;
+      align-content: flex-start;
+      overflow-y: auto;
     }
 
     .lca-warning {
       grid-column: 1 / -1;
       color: #ffb347;
       font-weight: 600;
+    }
+
+    @media (max-width: 960px) {
+      .lca-container {
+        grid-template-columns: minmax(240px, 1fr) minmax(280px, 1fr);
+      }
+    }
+
+    @media (max-width: 720px) {
+      .lca-container {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto minmax(0, 1fr);
+        grid-template-areas:
+          "header"
+          "visual"
+          "info";
+      }
+
+      .lca-header {
+        grid-template-columns: 1fr;
+      }
+
+      .lca-info {
+        overflow-y: visible;
+      }
+
+      .lca-visual {
+        min-height: 220px;
+      }
     }
   </style>
   <div class="lca-header">


### PR DESCRIPTION
## Summary
- redesign the lane centering assist widget layout to use a horizontal two-column grid
- improve responsiveness with dynamic spacing, font scaling, and overflow handling for the info list
- add viewport breakpoints so the widget adapts cleanly on narrower widths

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cfe1ddc6f883298d96d848a38fa8f1