### PR TITLE
Improve lane selection robustness and UI lane rendering

### DIFF
--- a/ui/modules/apps/laneCenteringAssistApp/app.js
+++ b/ui/modules/apps/laneCenteringAssistApp/app.js
@@ -462,6 +462,12 @@ angular.module('beamng.apps')
         } else if (lane && typeof lane.width === 'number' && isFinite(lane.width)) {
           laneWidthValue = lane.width
         }
+        if (laneInfo && typeof laneInfo.roadWidth === 'number' && isFinite(laneInfo.roadWidth) && laneOffsets && laneOffsets.length) {
+          var derivedLaneWidth = laneInfo.roadWidth / laneOffsets.length
+          if (derivedLaneWidth > 0 && (!laneWidthValue || !isFinite(laneWidthValue) || laneWidthValue <= 0)) {
+            laneWidthValue = derivedLaneWidth
+          }
+        }
 
         var laneHalfWidth = (typeof laneWidthValue === 'number' && isFinite(laneWidthValue)) ? laneWidthValue * 0.5 : null
         var laneOffset = (lane && lane.offset) || {}
@@ -522,6 +528,9 @@ angular.module('beamng.apps')
           if (!laneHalfSpacing && typeof laneWidthValue === 'number' && isFinite(laneWidthValue)) {
             laneHalfSpacing = laneWidthValue * 0.5
           }
+          if ((!laneHalfSpacing || laneHalfSpacing <= 0) && laneInfo && typeof laneInfo.roadWidth === 'number' && isFinite(laneInfo.roadWidth) && laneOffsets.length) {
+            laneHalfSpacing = (laneInfo.roadWidth / laneOffsets.length) * 0.5
+          }
           for (var li = 0; li < laneOffsets.length; li++) {
             var offsetVal = laneOffsets[li]
             if (typeof offsetVal !== 'number' || !isFinite(offsetVal)) continue
@@ -544,6 +553,30 @@ angular.module('beamng.apps')
                 boundaryMap[rightKey] = rightEntry
               }
               rightEntry.count += 1
+            }
+          }
+          if (laneInfo) {
+            if (typeof laneInfo.roadLeft === 'number' && isFinite(laneInfo.roadLeft)) {
+              var leftEdge = laneInfo.roadLeft - baselineOffset
+              var leftEdgeKey = leftEdge.toFixed(4)
+              var existingLeft = boundaryMap[leftEdgeKey]
+              if (!existingLeft) {
+                boundaryMap[leftEdgeKey] = { value: leftEdge, count: laneOffsets.length }
+              } else {
+                existingLeft.value = leftEdge
+                existingLeft.count = Math.max(existingLeft.count, laneOffsets.length)
+              }
+            }
+            if (typeof laneInfo.roadRight === 'number' && isFinite(laneInfo.roadRight)) {
+              var rightEdge = laneInfo.roadRight - baselineOffset
+              var rightEdgeKey = rightEdge.toFixed(4)
+              var existingRight = boundaryMap[rightEdgeKey]
+              if (!existingRight) {
+                boundaryMap[rightEdgeKey] = { value: rightEdge, count: laneOffsets.length }
+              } else {
+                existingRight.value = rightEdge
+                existingRight.count = Math.max(existingRight.count, laneOffsets.length)
+              }
             }
           }
           var boundaryKeys = Object.keys(boundaryMap)


### PR DESCRIPTION
## Summary
- derive per-direction lane counts and widths from map lane metadata for more reliable offset generation
- refine lane geometry using world samples, smooth lane selections, clamp candidate turns, and prefer lane-based road distance to prevent false off-road triggers
- update the Lane Centering Assist UI to respect computed road widths and bounds so all lanes render consistently

## Testing
- No automated tests were run (lua binary not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d02fefec14832985aee11f5c833aab