### PR TITLE
Fix LiDAR obstacle detection filtering

### DIFF
--- a/vehicles/citybus/parameters.lua
+++ b/vehicles/citybus/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/common/parameters.lua
+++ b/vehicles/common/parameters.lua
@@ -25,7 +25,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 9,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = 0.0,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/etk800/parameters.lua
+++ b/vehicles/etk800/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/etkc/parameters.lua
+++ b/vehicles/etkc/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/sbr/parameters.lua
+++ b/vehicles/sbr/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/sunburst/parameters.lua
+++ b/vehicles/sunburst/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {

--- a/vehicles/vivace/parameters.lua
+++ b/vehicles/vivace/parameters.lua
@@ -22,7 +22,14 @@ M.fwd_aeb_params = {
     num_of_sensors = 5,
     sensors_polled_per_iteration = 1,
     sensor_offset_forward = -0.3,
-    sensor_max_distance = 60
+    sensor_max_distance = 60,
+
+    lidar_detection_extra = 20,
+    lidar_ground_height_window = 0.45,
+    lidar_ground_window_forward_scale = 45,
+    lidar_far_distance_threshold = 40,
+    lidar_far_block_ratio_threshold = 0.3,
+    lidar_bin_gap_tolerance = 2
 }
 
 M.rev_aeb_params = {


### PR DESCRIPTION
## Summary
- adjust the obstacle filtering so LiDAR points at vehicle height contribute to the braking distance
- capture the LiDAR-based distance used by the obstacle braking system and expose it through the logger

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d05b813b9883298f4d0cf242d83b55