### PR TITLE
Reduce ADAS telemetry overhead

### DIFF
--- a/scripts/driver_assistance_angelo234/extension.lua
+++ b/scripts/driver_assistance_angelo234/extension.lua
@@ -1659,7 +1659,9 @@ local function onUpdate(dt)
   --p:start()
 
   lidarPcdStream.update(dt)
-  extra_utils.beginFrame(dt)
+  if extra_utils.beginFrame then
+    extra_utils.beginFrame(dt)
+  end
 
   if first_update then
     if sensor_system.init then sensor_system.init() end


### PR DESCRIPTION
## Summary
- derive per-vehicle acceleration from velocity deltas on the game-engine side and expose frame lifecycle helpers
- stop queueing Lua telemetry for every vehicle each frame and reset cached motion state on vehicle switches/unloads
- keep the legacy acceleration table in sync for compatibility while cleaning up state when vehicles are destroyed

## Testing
- ⚠️ `luac -p scripts/driver_assistance_angelo234/extension.lua` *(not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f46db8b88329b1a1d61f269e8b43